### PR TITLE
feat: #9 JWT 관련 컴포넌트/로그아웃 API 개발

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,9 +28,15 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.0'  // Swagger
+
+    // JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.13.0'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.13.0'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.13.0'
 
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -40,10 +40,14 @@ dependencies {
 
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
+    runtimeOnly 'com.h2database:h2'
     testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-security-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    testImplementation 'org.testcontainers:junit-jupiter:1.21.3'
+    testImplementation "org.testcontainers:testcontainers"
 }
 
 tasks.named('test') {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,5 +12,18 @@ services:
     volumes:
       - swyp-mysql-data:/var/lib/mysql
 
+  redis:
+    image: redis:alpine
+    container_name: swyp-redis
+    ports:
+      - "16379:6379"
+    environment:
+      - REDIS_HOST=localhost
+      - REDIS_PASSWORD=swyp1234
+    command:
+      - /bin/sh
+      - -c
+      - redis-server --requirepass "$${REDIS_PASSWORD:?REDIS_PASSWORD variable is not set}"
+
 volumes:
   swyp-mysql-data:

--- a/src/main/java/pyws/swyp/SwypApplication.java
+++ b/src/main/java/pyws/swyp/SwypApplication.java
@@ -2,8 +2,10 @@ package pyws.swyp;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 @SpringBootApplication
+@ConfigurationPropertiesScan
 public class SwypApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/pyws/swyp/auth/controller/AuthController.java
+++ b/src/main/java/pyws/swyp/auth/controller/AuthController.java
@@ -1,6 +1,7 @@
 package pyws.swyp.auth.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -8,9 +9,12 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import pyws.swyp.auth.controller.api.AuthApi;
 import pyws.swyp.auth.dto.AuthResponse;
+import pyws.swyp.auth.dto.JwtResponse;
 import pyws.swyp.auth.dto.LoginRequest;
+import pyws.swyp.auth.dto.ReissueRequest;
 import pyws.swyp.auth.dto.SignupRequest;
 import pyws.swyp.auth.service.AuthService;
+import pyws.swyp.auth.service.JwtService;
 
 @RestController
 @RequiredArgsConstructor
@@ -18,19 +22,25 @@ import pyws.swyp.auth.service.AuthService;
 public class AuthController implements AuthApi {
 
     private final AuthService authService;
+    private final JwtService jwtService;
 
     @PostMapping("/login")
     public AuthResponse login(@RequestBody @Validated LoginRequest request) {
         return authService.login(request);
     }
 
-    @PostMapping("/logout")
-    public void logout() {
-
-    }
-
     @PostMapping("/signup")
     public AuthResponse signup(@RequestBody @Validated SignupRequest request) {
         return authService.signup(request);
+    }
+
+    @PostMapping("/logout")
+    public void logout(@AuthenticationPrincipal Long memberId) {
+        authService.logout(memberId);
+    }
+
+    @PostMapping("/reissue")
+    public JwtResponse reissue(@RequestBody @Validated ReissueRequest request) {
+        return jwtService.reissue(request.refreshToken());
     }
 }

--- a/src/main/java/pyws/swyp/auth/controller/api/AuthApi.java
+++ b/src/main/java/pyws/swyp/auth/controller/api/AuthApi.java
@@ -1,21 +1,25 @@
 package pyws.swyp.auth.controller.api;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import pyws.swyp.auth.dto.AuthResponse;
+import pyws.swyp.auth.dto.JwtResponse;
 import pyws.swyp.auth.dto.LoginRequest;
+import pyws.swyp.auth.dto.ReissueRequest;
 import pyws.swyp.auth.dto.SignupRequest;
 
 @Tag(name = "Auth API", description = "로그인 / 로그아웃 / 회원가입 / 토큰 재발급 API")
 public interface AuthApi {
 
     @Operation(
-            summary = "소셜 로그인",
+            summary = "로그인",
             description =
                     """
                             로그인 요청을 처리합니다.
@@ -76,10 +80,10 @@ public interface AuthApi {
                             
                             요청 구조:
                             - login: 소셜 정보 (socialProvider, socialId, email)
-                            - nickname, birthday, gender
+                            - nickname, birthdate, gender
                             
                             응답:
-                            - signupRequired: 항상 false
+                            - signupRequired: false
                             - tokens: 로그인 완료 후 발급된 JWT(access, refresh)
                             """
     )
@@ -110,4 +114,75 @@ public interface AuthApi {
             )
     )
     AuthResponse signup(@RequestBody @Validated SignupRequest request);
+
+    @Operation(
+            summary = "로그아웃",
+            description =
+                    """
+                            현재 로그인된 사용자를 로그아웃 처리합니다.
+                            
+                            - Redis에 저장된 Refresh Token을 삭제합니다.
+                            - Access Token은 만료 시점까지 유효하지만,
+                              이후 재발급은 불가능합니다.
+                            
+                            Authorization 헤더에 Access Token이 필요합니다.
+                            """
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "로그아웃 성공",
+            content = @Content(
+                    mediaType = "application/json",
+                    examples = {
+                            @ExampleObject(
+                                    value = """
+                                            {
+                                              "code": "SUCCESS",
+                                              "message": "요청이 성공적으로 처리되었습니다."
+                                            }
+                                            """
+                            )
+                    }
+            )
+    )
+    void logout(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal Long memberId
+    );
+
+    @Operation(
+            summary = "토큰 재발급",
+            description =
+                    """
+                            Refresh Token을 이용해 Access / Refresh Token을 재발급합니다.
+                            
+                            - Refresh Token 검증 및 Redis 저장값과의 일치 여부를 확인합니다.
+                            - 유효한 경우, 기존 토큰은 무효화되고 새로운 토큰 쌍이 발급됩니다.
+                            - Access Token 만료 시 호출됩니다.
+                            """
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "토큰 재발급 성공",
+            content = @Content(
+                    mediaType = "application/json",
+                    examples = {
+                            @ExampleObject(
+                                    name = "재발급 성공",
+                                    summary = "Access / Refresh Token 재발급",
+                                    value = """
+                                            {
+                                              "code": "SUCCESS",
+                                              "message": "요청이 성공적으로 처리되었습니다.",
+                                              "data": {
+                                                "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+                                                "refreshToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+                                              }
+                                            }
+                                            """
+                            )
+                    }
+            )
+    )
+    JwtResponse reissue(@RequestBody @Validated ReissueRequest request);
 }

--- a/src/main/java/pyws/swyp/auth/dto/ReissueRequest.java
+++ b/src/main/java/pyws/swyp/auth/dto/ReissueRequest.java
@@ -1,0 +1,9 @@
+package pyws.swyp.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record ReissueRequest(
+        @NotBlank(message = "Refresh Token은 필수입니다.")
+        String refreshToken
+) {
+}

--- a/src/main/java/pyws/swyp/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/pyws/swyp/auth/repository/RefreshTokenRepository.java
@@ -1,9 +1,8 @@
 package pyws.swyp.auth.repository;
 
-import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Repository;
+import pyws.swyp.global.component.RedisComponent;
 import pyws.swyp.global.jwt.JwtProperties;
 import pyws.swyp.global.jwt.TokenHasher;
 
@@ -14,19 +13,22 @@ public class RefreshTokenRepository {
     private static final String PREFIX = "refresh:";
 
     private final JwtProperties props;
-    private final StringRedisTemplate redisTemplate;
+    private final RedisComponent redisComponent;
 
     public void save(Long memberId, String refreshToken) {
-        String hashed = TokenHasher.hash(refreshToken);
-        redisTemplate.opsForValue().set(key(memberId), hashed, props.getRefreshTokenTtlMs(), TimeUnit.MILLISECONDS);
+        redisComponent.setString(
+                key(memberId),
+                TokenHasher.hash(refreshToken),
+                props.getRefreshTokenTtlMs()
+        );
     }
 
     public String find(Long memberId) {
-        return redisTemplate.opsForValue().get(key(memberId));
+        return redisComponent.getString(key(memberId));
     }
 
     public void delete(Long memberId) {
-        redisTemplate.delete(key(memberId));
+        redisComponent.delete(key(memberId));
     }
 
     public boolean matches(Long memberId, String refreshToken) {

--- a/src/main/java/pyws/swyp/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/pyws/swyp/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,42 @@
+package pyws.swyp.auth.repository;
+
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+import pyws.swyp.global.jwt.JwtProperties;
+import pyws.swyp.global.jwt.TokenHasher;
+
+@Repository
+@RequiredArgsConstructor
+public class RefreshTokenRepository {
+
+    private static final String PREFIX = "refresh:";
+
+    private final JwtProperties props;
+    private final StringRedisTemplate redisTemplate;
+
+    public void save(Long memberId, String refreshToken) {
+        String hashed = TokenHasher.hash(refreshToken);
+        redisTemplate.opsForValue().set(key(memberId), hashed, props.getRefreshTokenTtlMs(), TimeUnit.MILLISECONDS);
+    }
+
+    public String find(Long memberId) {
+        return redisTemplate.opsForValue().get(key(memberId));
+    }
+
+    public void delete(Long memberId) {
+        redisTemplate.delete(key(memberId));
+    }
+
+    public boolean matches(Long memberId, String refreshToken) {
+        String hashed = TokenHasher.hash(refreshToken);
+        String storedHashed = find(memberId);
+        return hashed.equals(storedHashed);
+    }
+
+    private String key(Long memberId) {
+        return PREFIX + memberId;
+    }
+}
+

--- a/src/main/java/pyws/swyp/auth/service/AuthService.java
+++ b/src/main/java/pyws/swyp/auth/service/AuthService.java
@@ -1,14 +1,15 @@
 package pyws.swyp.auth.service;
 
+import static pyws.swyp.global.error.ErrorCode.SOCIAL_ACCOUNT_ALREADY_EXISTS;
+
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import pyws.swyp.auth.dto.AuthResponse;
+import pyws.swyp.auth.dto.JwtResponse;
 import pyws.swyp.auth.dto.LoginRequest;
 import pyws.swyp.auth.dto.SignupRequest;
-import pyws.swyp.global.error.CustomException;
-import pyws.swyp.global.error.ErrorCode;
 import pyws.swyp.member.entity.Member;
 import pyws.swyp.member.entity.SocialAccount;
 import pyws.swyp.member.repository.MemberRepository;
@@ -20,6 +21,7 @@ public class AuthService {
 
     private final MemberRepository memberRepository;
     private final SocialAccountRepository socialAccountRepository;
+    private final JwtService jwtService;
 
     @Transactional(readOnly = true)
     public AuthResponse login(LoginRequest request) {
@@ -36,7 +38,10 @@ public class AuthService {
         }
 
         // 기존 회원 -> JWT 발급
-        return new AuthResponse(false, null);
+        Long memberId = socialAccountOpt.get().getMember().getId();
+        JwtResponse tokens = jwtService.issueTokens(memberId);
+
+        return new AuthResponse(false, tokens);
     }
 
     @Transactional
@@ -49,7 +54,7 @@ public class AuthService {
                 login.socialProvider(),
                 login.socialId()
         ).ifPresent(socialAccount -> {
-            throw new CustomException(ErrorCode.SOCIAL_ACCOUNT_ALREADY_EXISTS);
+            throw SOCIAL_ACCOUNT_ALREADY_EXISTS.toException();
         });
 
         // 회원 생성
@@ -69,6 +74,13 @@ public class AuthService {
                 .build();
         socialAccountRepository.save(socialAccount);
 
-        return new AuthResponse(false, null);
+        // 로그인 처리
+        JwtResponse tokens = jwtService.issueTokens(member.getId());
+
+        return new AuthResponse(false, tokens);
+    }
+
+    public void logout(Long memberId) {
+        jwtService.logout(memberId);
     }
 }

--- a/src/main/java/pyws/swyp/auth/service/JwtService.java
+++ b/src/main/java/pyws/swyp/auth/service/JwtService.java
@@ -1,0 +1,50 @@
+package pyws.swyp.auth.service;
+
+import static pyws.swyp.global.error.ErrorCode.UNAUTHORIZED;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import pyws.swyp.auth.dto.JwtResponse;
+import pyws.swyp.auth.repository.RefreshTokenRepository;
+import pyws.swyp.global.jwt.JwtProvider;
+
+@Service
+@RequiredArgsConstructor
+public class JwtService {
+
+    private final JwtProvider jwtProvider;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    public JwtResponse issueTokens(Long memberId) {
+        String accessToken = jwtProvider.createAccessToken(memberId);
+        String refreshToken = jwtProvider.createRefreshToken(memberId);
+
+        refreshTokenRepository.save(memberId, refreshToken);
+
+        return new JwtResponse(accessToken, refreshToken);
+    }
+
+    public JwtResponse reissue(String refreshToken) {
+        // Refresh Token 유효성 검증
+        Boolean isValid = jwtProvider.validateToken(refreshToken, false);
+        if (!isValid) {
+            throw UNAUTHORIZED.toException();
+        }
+
+        Long memberId = jwtProvider.getMemberId(refreshToken);
+
+        // Redis에 저장된 Refresh Token과 일치하는지 확인
+        boolean matches = refreshTokenRepository.matches(memberId, refreshToken);
+        if (!matches) {  // 폐기된 Refresh Token일 가능성 -> 로그아웃 처리
+            refreshTokenRepository.delete(memberId);
+            throw UNAUTHORIZED.toException();
+        }
+
+        // 재발급하여 반환
+        return issueTokens(memberId);
+    }
+
+    public void logout(Long memberId) {
+        refreshTokenRepository.delete(memberId);
+    }
+}

--- a/src/main/java/pyws/swyp/global/api/ApiResponse.java
+++ b/src/main/java/pyws/swyp/global/api/ApiResponse.java
@@ -1,10 +1,12 @@
 package pyws.swyp.global.api;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ApiResponse<T> {
 
     private String code;

--- a/src/main/java/pyws/swyp/global/component/RedisComponent.java
+++ b/src/main/java/pyws/swyp/global/component/RedisComponent.java
@@ -1,0 +1,54 @@
+package pyws.swyp.global.component;
+
+import static pyws.swyp.global.error.ErrorCode.REDIS_DESERIALIZATION_ERROR;
+import static pyws.swyp.global.error.ErrorCode.REDIS_SERIALIZATION_ERROR;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RedisComponent {
+
+    private final StringRedisTemplate redisTemplate;
+    private final ObjectMapper objectMapper;
+
+    public String getString(String key) {
+        return redisTemplate.opsForValue().get(key);
+    }
+
+    public void setString(String key, String value, long ttlMs) {
+        redisTemplate.opsForValue().set(key, value, ttlMs, TimeUnit.MILLISECONDS);
+    }
+
+    public void delete(String key) {
+        redisTemplate.delete(key);
+    }
+
+    public <T> T getJson(String key, Class<T> clazz) {
+        String json = redisTemplate.opsForValue().get(key);
+        if (json == null) {
+            return null;
+        }
+
+        try {
+            return objectMapper.readValue(json, clazz);
+        } catch (JsonProcessingException e) {
+            throw REDIS_DESERIALIZATION_ERROR.toException();
+        }
+    }
+
+    public <T> void setJson(String key, T value, long ttlMs) {
+        try {
+            String json = objectMapper.writeValueAsString(value);
+            redisTemplate.opsForValue()
+                    .set(key, json, ttlMs, TimeUnit.MILLISECONDS);
+        } catch (JsonProcessingException e) {
+            throw REDIS_SERIALIZATION_ERROR.toException();
+        }
+    }
+}

--- a/src/main/java/pyws/swyp/global/config/JacksonConfig.java
+++ b/src/main/java/pyws/swyp/global/config/JacksonConfig.java
@@ -1,0 +1,14 @@
+package pyws.swyp.global.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JacksonConfig {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper();
+    }
+}

--- a/src/main/java/pyws/swyp/global/config/RedisConfig.java
+++ b/src/main/java/pyws/swyp/global/config/RedisConfig.java
@@ -1,13 +1,11 @@
 package pyws.swyp.global.config;
 
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.StringRedisTemplate;
 
 @Configuration
-@EnableConfigurationProperties
 public class RedisConfig {
 
     @Bean

--- a/src/main/java/pyws/swyp/global/config/RedisConfig.java
+++ b/src/main/java/pyws/swyp/global/config/RedisConfig.java
@@ -1,0 +1,17 @@
+package pyws.swyp.global.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+@Configuration
+@EnableConfigurationProperties
+public class RedisConfig {
+
+    @Bean
+    public StringRedisTemplate stringRedisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        return new StringRedisTemplate(redisConnectionFactory);
+    }
+}

--- a/src/main/java/pyws/swyp/global/error/ErrorCode.java
+++ b/src/main/java/pyws/swyp/global/error/ErrorCode.java
@@ -1,6 +1,9 @@
 package pyws.swyp.global.error;
 
-import static org.springframework.http.HttpStatus.*;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.CONFLICT;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -10,9 +13,18 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ErrorCode {
 
-    INVALID_INPUT(BAD_REQUEST,"COM0001", "잘못된 요청입니다."),
+    // 공통
+    INVALID_INPUT(BAD_REQUEST, "COM0001", "잘못된 요청입니다."),
+
+    // Redis
+    REDIS_SERIALIZATION_ERROR(INTERNAL_SERVER_ERROR, "RED0001", "Redis 데이터 직렬화에 실패했습니다."),
+    REDIS_DESERIALIZATION_ERROR(INTERNAL_SERVER_ERROR, "RED0002", "Redis 데이터 역직렬화에 실패했습니다."),
+
+    // Security
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "AUTH0001", "인증이 필요합니다."),
     FORBIDDEN(HttpStatus.FORBIDDEN, "AUTH0002", "접근 권한이 없습니다."),
+
+    // Member
     MEMBER_NOT_FOUND(NOT_FOUND, "MEM0001", "존재하지 않는 회원입니다."),
     SOCIAL_ACCOUNT_ALREADY_EXISTS(CONFLICT, "SOC0001", "이미 가입된 소셜 계정입니다.");
 

--- a/src/main/java/pyws/swyp/global/error/ErrorCode.java
+++ b/src/main/java/pyws/swyp/global/error/ErrorCode.java
@@ -11,10 +11,16 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
 
     INVALID_INPUT(BAD_REQUEST,"COM0001", "잘못된 요청입니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "AUTH0001", "인증이 필요합니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "AUTH0002", "접근 권한이 없습니다."),
     MEMBER_NOT_FOUND(NOT_FOUND, "MEM0001", "존재하지 않는 회원입니다."),
     SOCIAL_ACCOUNT_ALREADY_EXISTS(CONFLICT, "SOC0001", "이미 가입된 소셜 계정입니다.");
 
     private final HttpStatus status;
     private final String code;
     private final String message;
+
+    public CustomException toException() {
+        return new CustomException(this);
+    }
 }

--- a/src/main/java/pyws/swyp/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/pyws/swyp/global/error/GlobalExceptionHandler.java
@@ -8,7 +8,6 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-import tools.jackson.databind.exc.InvalidFormatException;
 import tools.jackson.databind.exc.MismatchedInputException;
 
 @RestControllerAdvice

--- a/src/main/java/pyws/swyp/global/jwt/JwtProperties.java
+++ b/src/main/java/pyws/swyp/global/jwt/JwtProperties.java
@@ -1,0 +1,16 @@
+package pyws.swyp.global.jwt;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "jwt")
+public class JwtProperties {
+
+    private String issuer;
+    private String secretKey;
+    private long accessTokenTtlMs;
+    private long refreshTokenTtlMs;
+}

--- a/src/main/java/pyws/swyp/global/jwt/JwtProvider.java
+++ b/src/main/java/pyws/swyp/global/jwt/JwtProvider.java
@@ -1,0 +1,82 @@
+package pyws.swyp.global.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import jakarta.annotation.PostConstruct;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.Date;
+import javax.crypto.SecretKey;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class JwtProvider {
+
+    private final JwtProperties props;
+    private SecretKey key;
+
+    @PostConstruct
+    void init() {
+        byte[] decoded = Base64.getDecoder().decode(props.getSecretKey());
+        this.key = io.jsonwebtoken.security.Keys.hmacShaKeyFor(decoded);
+    }
+
+    public String createAccessToken(Long memberId) {
+        return createToken(memberId, "access", props.getAccessTokenTtlMs());
+    }
+
+    public String createRefreshToken(Long memberId) {
+        return createToken(memberId, "refresh", props.getRefreshTokenTtlMs());
+    }
+
+    private String createToken(Long memberId, String type, long ttlMs) {
+        Instant now = Instant.now();
+        Instant exp = now.plusMillis(ttlMs);
+
+        return Jwts.builder()
+                .issuer(props.getIssuer())
+                .subject(String.valueOf(memberId))
+                .claim("typ", type)
+                .issuedAt(Date.from(now))
+                .expiration(Date.from(exp))
+                .signWith(key)
+                .compact();
+    }
+
+    public Jws<Claims> parse(String token) {
+        return Jwts.parser()
+                .verifyWith(key)
+                .requireIssuer(props.getIssuer())
+                .build()
+                .parseSignedClaims(token);
+    }
+
+    public Boolean validateToken(String token, Boolean isAccessToken) {
+        try {
+            Object typeObj = parse(token).getPayload().get("typ");
+            if (typeObj == null) {
+                return false;
+            }
+            String type = typeObj.toString();
+
+            if (isAccessToken && !type.equals("access")) {
+                return false;
+            }
+            if (!isAccessToken && !type.equals("refresh")) {
+                return false;
+            }
+
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    public Long getMemberId(String token) {
+        return Long.parseLong(parse(token).getPayload().getSubject());
+    }
+}

--- a/src/main/java/pyws/swyp/global/jwt/TokenHasher.java
+++ b/src/main/java/pyws/swyp/global/jwt/TokenHasher.java
@@ -1,0 +1,23 @@
+package pyws.swyp.global.jwt;
+
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+public class TokenHasher {
+
+    public static String hash(String token) {
+        try {
+            Mac mac = Mac.getInstance("HmacSHA256");
+            SecretKeySpec key = new SecretKeySpec(token.getBytes(), "HmacSHA256");
+            mac.init(key);
+
+            byte[] result = mac.doFinal(token.getBytes());
+            return Base64.getEncoder().encodeToString(result);
+        } catch (NoSuchAlgorithmException | InvalidKeyException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/pyws/swyp/global/security/ApiAccessDeniedHandler.java
+++ b/src/main/java/pyws/swyp/global/security/ApiAccessDeniedHandler.java
@@ -1,0 +1,27 @@
+package pyws.swyp.global.security;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+import pyws.swyp.global.error.ErrorCode;
+import pyws.swyp.global.error.ErrorResponse;
+import tools.jackson.databind.ObjectMapper;
+
+@Component
+public class ApiAccessDeniedHandler implements AccessDeniedHandler {
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response,
+                       AccessDeniedException accessDeniedException) throws IOException {
+
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.setContentType("application/json;charset=UTF-8");
+
+        ErrorResponse body = new ErrorResponse(ErrorCode.FORBIDDEN);
+
+        response.getWriter().write(new ObjectMapper().writeValueAsString(body));
+    }
+}

--- a/src/main/java/pyws/swyp/global/security/ApiAccessDeniedHandler.java
+++ b/src/main/java/pyws/swyp/global/security/ApiAccessDeniedHandler.java
@@ -1,17 +1,21 @@
 package pyws.swyp.global.security;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.stereotype.Component;
 import pyws.swyp.global.error.ErrorCode;
 import pyws.swyp.global.error.ErrorResponse;
-import tools.jackson.databind.ObjectMapper;
 
 @Component
+@RequiredArgsConstructor
 public class ApiAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
 
     @Override
     public void handle(HttpServletRequest request, HttpServletResponse response,
@@ -22,6 +26,6 @@ public class ApiAccessDeniedHandler implements AccessDeniedHandler {
 
         ErrorResponse body = new ErrorResponse(ErrorCode.FORBIDDEN);
 
-        response.getWriter().write(new ObjectMapper().writeValueAsString(body));
+        response.getWriter().write(objectMapper.writeValueAsString(body));
     }
 }

--- a/src/main/java/pyws/swyp/global/security/ApiAuthenticationEntryPoint.java
+++ b/src/main/java/pyws/swyp/global/security/ApiAuthenticationEntryPoint.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
@@ -11,7 +12,10 @@ import pyws.swyp.global.error.ErrorCode;
 import pyws.swyp.global.error.ErrorResponse;
 
 @Component
+@RequiredArgsConstructor
 public class ApiAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
 
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response,
@@ -22,6 +26,6 @@ public class ApiAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
         ErrorResponse body = new ErrorResponse(ErrorCode.UNAUTHORIZED);
 
-        response.getWriter().write(new ObjectMapper().writeValueAsString(body));
+        response.getWriter().write(objectMapper.writeValueAsString(body));
     }
 }

--- a/src/main/java/pyws/swyp/global/security/ApiAuthenticationEntryPoint.java
+++ b/src/main/java/pyws/swyp/global/security/ApiAuthenticationEntryPoint.java
@@ -1,0 +1,27 @@
+package pyws.swyp.global.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+import pyws.swyp.global.error.ErrorCode;
+import pyws.swyp.global.error.ErrorResponse;
+
+@Component
+public class ApiAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json;charset=UTF-8");
+
+        ErrorResponse body = new ErrorResponse(ErrorCode.UNAUTHORIZED);
+
+        response.getWriter().write(new ObjectMapper().writeValueAsString(body));
+    }
+}

--- a/src/main/java/pyws/swyp/global/security/JwtFilter.java
+++ b/src/main/java/pyws/swyp/global/security/JwtFilter.java
@@ -1,0 +1,50 @@
+package pyws.swyp.global.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import pyws.swyp.global.jwt.JwtProvider;
+
+@Component
+@RequiredArgsConstructor
+public class JwtFilter extends OncePerRequestFilter {
+
+    private final JwtProvider jwtProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String authorization = request.getHeader("Authorization");
+        if (authorization == null) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        if (!authorization.startsWith("Bearer ")) {
+            throw new ServletException("Invalid JWT");
+        }
+
+        String accessToken = authorization.replace("Bearer ", "");
+
+        Boolean isAccessToken = jwtProvider.validateToken(accessToken, true);
+        if (isAccessToken) {
+            Long memberId = jwtProvider.getMemberId(accessToken);
+
+            var auth = new UsernamePasswordAuthenticationToken(memberId, null, List.of());
+            SecurityContextHolder.getContext().setAuthentication(auth);
+        } else {
+            SecurityContextHolder.clearContext();
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/pyws/swyp/global/security/SecurityConfig.java
+++ b/src/main/java/pyws/swyp/global/security/SecurityConfig.java
@@ -1,5 +1,6 @@
 package pyws.swyp.global.security;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -9,10 +10,16 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtFilter jwtFilter;
+    private final ApiAuthenticationEntryPoint entryPoint;
+    private final ApiAccessDeniedHandler deniedHandler;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -25,9 +32,14 @@ public class SecurityConfig {
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**",
                                 "/api/auth/login",
-                                "/api/auth/signup"
+                                "/api/auth/signup",
+                                "/api/auth/reissue"
                         ).permitAll()
-                        .anyRequest().permitAll())
+                        .anyRequest().authenticated())
+                .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
+                .exceptionHandling(handler -> handler
+                        .authenticationEntryPoint(entryPoint)
+                        .accessDeniedHandler(deniedHandler))
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .build();

--- a/src/test/http/auth.http
+++ b/src/test/http/auth.http
@@ -43,11 +43,11 @@ Content-Type: application/json
     client.global.set("refreshToken", response.body.data.tokens.refreshToken);
 %}
 
-#### 로그아웃
+### 로그아웃
 POST http://localhost:8080/api/auth/logout
 Authorization: Bearer {{accessToken}}
 
-#### 토큰 재발급
+### 토큰 재발급
 POST http://localhost:8080/api/auth/reissue
 Content-Type: application/json
 

--- a/src/test/http/auth.http
+++ b/src/test/http/auth.http
@@ -8,6 +8,11 @@ Content-Type: application/json
   "email": "existing@example.com"
 }
 
+> {%
+    client.global.set("accessToken", response.body.data.tokens.accessToken);
+    client.global.set("refreshToken", response.body.data.tokens.refreshToken);
+%}
+
 ### 소셜 로그인 요청 (신규 회원인 경우)
 POST http://localhost:8080/api/auth/login
 Content-Type: application/json
@@ -33,9 +38,24 @@ Content-Type: application/json
   "gender": "MALE"
 }
 
-#### 🟥 로그아웃
-#POST http://localhost:8080/api/auth/logout
-#
-#### 🟫 보호된 API 테스트 (로그인 후 받은 accessToken 넣어서 테스트)
-#GET http://localhost:8080/api/members/me
-#Authorization: Bearer {{accessToken}}
+> {%
+    client.global.set("accessToken", response.body.data.tokens.accessToken);
+    client.global.set("refreshToken", response.body.data.tokens.refreshToken);
+%}
+
+#### 로그아웃
+POST http://localhost:8080/api/auth/logout
+Authorization: Bearer {{accessToken}}
+
+#### 토큰 재발급
+POST http://localhost:8080/api/auth/reissue
+Content-Type: application/json
+
+{
+  "refreshToken": "{{refreshToken}}"
+}
+
+> {%
+    client.global.set("accessToken", response.body.data.accessToken);
+    client.global.set("refreshToken", response.body.data.refreshToken);
+%}

--- a/src/test/java/pyws/swyp/config/TestRedisConfig.java
+++ b/src/test/java/pyws/swyp/config/TestRedisConfig.java
@@ -1,0 +1,40 @@
+package pyws.swyp.config;
+
+import jakarta.annotation.PreDestroy;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@TestConfiguration
+@Testcontainers
+public class TestRedisConfig {
+
+    @Container
+    private static final GenericContainer<?> redisContainer;
+
+    static {
+        redisContainer = new GenericContainer<>("redis:7-alpine")
+                .withExposedPorts(6379);
+        redisContainer.start();
+
+        String host = redisContainer.getHost();
+        Integer port = redisContainer.getMappedPort(6379);
+
+        System.setProperty("spring.data.redis.host", host);
+        System.setProperty("spring.data.redis.port", port.toString());
+    }
+
+    @Bean
+    public GenericContainer<?> redisContainer() {
+        return redisContainer;
+    }
+
+    @PreDestroy
+    public void stop() {
+        if (redisContainer.isRunning()) {
+            redisContainer.stop();
+        }
+    }
+}

--- a/src/test/java/pyws/swyp/global/component/RedisComponentTest.java
+++ b/src/test/java/pyws/swyp/global/component/RedisComponentTest.java
@@ -1,0 +1,108 @@
+package pyws.swyp.global.component;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import pyws.swyp.config.TestRedisConfig;
+
+@SpringBootTest
+@Import(TestRedisConfig.class)
+class RedisComponentTest {
+
+    @Autowired
+    RedisComponent redisComponent;
+
+    @Test
+    @DisplayName("String 저장/조회에 성공한다")
+    void setGetString_success() {
+        // given
+        String key = "test:string:" + UUID.randomUUID();
+        String value = "foo";
+
+        // when
+        redisComponent.setString(key, value, 10_000);
+
+        // then
+        String loaded = redisComponent.getString(key);
+        assertEquals(loaded, value);
+    }
+
+    @Test
+    @DisplayName("delete 호출 시 key가 삭제된다")
+    void delete_success() {
+        // given
+        String key = "test:del:" + UUID.randomUUID();
+        redisComponent.setString(key, "bar", 10_000);
+
+        // when
+        redisComponent.delete(key);
+
+        // then
+        assertNull(redisComponent.getString(key));
+    }
+
+    @Test
+    @DisplayName("JSON 저장/조회에 성공한다")
+    void setGetJson_success() {
+        // given
+        String key = "test:json:" + UUID.randomUUID();
+        TestDto dto = new TestDto(1L, "baz");
+
+        // when
+        redisComponent.setJson(key, dto, 10_000);
+
+        // then
+        TestDto loaded = redisComponent.getJson(key, TestDto.class);
+        assertEquals(loaded, dto);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 key의 getJson은 null을 반환한다")
+    void getJson_nullWhenNotExists() {
+        // given
+        String key = "test:json:missing:" + UUID.randomUUID();
+
+        // when
+        TestDto loaded = redisComponent.getJson(key, TestDto.class);
+
+        // then
+        assertNull(loaded);
+    }
+
+    @Test
+    @DisplayName("TTL이 지나면 String 값이 만료된다")
+    void ttl_expire_string() throws InterruptedException {
+        // given
+        String key = "test:ttl:string:" + UUID.randomUUID();
+
+        // when
+        redisComponent.setString(key, "qux", 200);
+        Thread.sleep(350);
+
+        // then
+        assertNull(redisComponent.getString(key));
+    }
+
+    @Test
+    @DisplayName("TTL이 지나면 JSON 값이 만료된다")
+    void ttl_expire_json() throws InterruptedException {
+        // given
+        String key = "test:ttl:json:" + UUID.randomUUID();
+        TestDto dto = new TestDto(2L, "quux");
+
+        // when
+        redisComponent.setJson(key, dto, 200);
+        Thread.sleep(350);
+
+        // then
+        assertNull(redisComponent.getString(key));
+    }
+
+    private record TestDto(Long id, String name) {}
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,20 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:test;NON_KEYWORDS=USER
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: create
+
+  sql:
+    init:
+      mode: never
+
+jwt:
+  issuer: swyp
+  secret-key: nlqoqoZvab6v8CZfyJL/WByEerJmqhvXMNozGYpmHS4ZYS0NCrQjvGMozwQRgC2HRWY46MDaHmut/mw4j3IOmw==
+  access-token-ttl-ms: 900000       # 15분
+  refresh-token-ttl-ms: 604800000   # 일주일


### PR DESCRIPTION
### 📌 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- 기능 추가

### 📌 관련 이슈
#9

### ✨ 반영 브랜치
feat/8 -> develop

### 📝 변경 사항
- JwtProvider / JwtService 등 JWT 컴포넌트 구현
- JWT 인증 필터 추가 및 401/403 예외 처리
- Access / Refresh Token 발급 및 재발급 로직 구현
- Refresh Token Redis 저장 및 검증 로직 추가
- 로그아웃 API 구현 (Refresh Token 삭제)

### ➕ 추가 메모

[`application-local.yml`](https://www.notion.so/2c4dc60fe5e28007955bc58412ef47d0?p=2bfdc60fe5e280f398c9cc522045c2dd&pm=s) 수정

### 🐛 테스트 결과

#### 소셜 로그인 요청 (기존 회원)
```
POST http://localhost:8080/api/auth/login
Content-Type: application/json

{
  "socialProvider": "KAKAO",
  "socialId": "existing-social-id-123",
  "email": "existing@example.com"
}
```

#### 응답 결과

```
HTTP/1.1 200 
Content-Type: application/json

{
  "code": "SUCCESS",
  "message": "요청이 성공적으로 처리되었습니다.",
  "data": {
    "signupRequired": false,
    "tokens": {
      "accessToken": "eyJhbGciOiJIUzUxMiJ9.eyJpc3MiOiJzd3lwIiwic3ViIjoiNCIsInR5cCI6ImFjY2VzcyIsImlhdCI6MTc2NTY0MTAwMiwiZXhwIjoxNzY1NjQxMDEyfQ.q2ld00-Am2G0DBw7wt7PYr_xR7U3p2O2vKVFVcgBpVd3qo8ROfvkaBFhmF7LymYRQU7q-Zxeb3h-zRRr_lVPoA",
      "refreshToken": "eyJhbGciOiJIUzUxMiJ9.eyJpc3MiOiJzd3lwIiwic3ViIjoiNCIsInR5cCI6InJlZnJlc2giLCJpYXQiOjE3NjU2NDEwMDIsImV4cCI6MTc2NjI0NTgwMn0.SIwx2YzJth-UZy8NzcXwbGrsOmt_PNTkpF6EgxB8ur8ADmX-uyA0a6tddzGFaLMwp0w8EJuJ3BmslwUwGf81AQ"
    }
  }
}
```

#### 회원가입 요청 (소셜 정보 + 유저 정보)

```
POST http://localhost:8080/api/auth/signup
Content-Type: application/json

{
  "login": {
    "socialProvider": "NAVER",
    "socialId": "new-social-id-999",
    "email": "newuser@example.com"
  },
  "nickname": "홍길동",
  "birthDate": "1998-01-03",
  "gender": "MALE"
}
```

#### 응답 결과

```
HTTP/1.1 200 
Content-Type: application/json

{
  "code": "SUCCESS",
  "message": "요청이 성공적으로 처리되었습니다.",
  "data": {
    "signupRequired": false,
    "tokens": {
      "accessToken": "eyJhbGciOiJIUzUxMiJ9.eyJpc3MiOiJzd3lwIiwic3ViIjoiNyIsInR5cCI6ImFjY2VzcyIsImlhdCI6MTc2NTY0MTA2NSwiZXhwIjoxNzY1NjQxMDc1fQ.mZkRP7V7ykXw-dHlrB6meeDQKTM_FodzJcZZjPK-scLmNFZAHe5U8naspAykQHXUeq3yhfeqlMBJR3vZrmJm6Q",
      "refreshToken": "eyJhbGciOiJIUzUxMiJ9.eyJpc3MiOiJzd3lwIiwic3ViIjoiNyIsInR5cCI6InJlZnJlc2giLCJpYXQiOjE3NjU2NDEwNjUsImV4cCI6MTc2NjI0NTg2NX0.AM3-Qtdqd58SPrZUd-4laKxy72z213YnY21mjPOKqUKfZ9GfjadQmGl2Ly61DH6H4wPgRPYExgkMrtwtGACQOg"
    }
  }
}
```

#### 로그아웃
```
POST http://localhost:8080/api/auth/logout
Authorization: Bearer {{accessToken}}
```

#### 응답 결과
```
HTTP/1.1 200 
Content-Type: application/json

{
  "code": "SUCCESS",
  "message": "요청이 성공적으로 처리되었습니다."
}
```

#### 토큰 재발급 요청 (Access Token 만료 시)

```
POST http://localhost:8080/api/auth/reissue
Content-Type: application/json

{
  "refreshToken": "{{refreshToken}}"
}
```

#### 응답 결과

```
HTTP/1.1 200 
Content-Type: application/json

{
  "code": "SUCCESS",
  "message": "요청이 성공적으로 처리되었습니다.",
  "data": {
    "accessToken": "eyJhbGciOiJIUzUxMiJ9.eyJpc3MiOiJzd3lwIiwic3ViIjoiNCIsInR5cCI6ImFjY2VzcyIsImlhdCI6MTc2NTY0MTIzMSwiZXhwIjoxNzY1NjQxMjQxfQ.6fmd76RcWiIx4aPHqzDrtHxreeP8yWg3QEsXUAub2-6P6TUNUfgYLpjEthLyew9IZBunvJ5rUTAZl-jPqzpjPg",
    "refreshToken": "eyJhbGciOiJIUzUxMiJ9.eyJpc3MiOiJzd3lwIiwic3ViIjoiNCIsInR5cCI6InJlZnJlc2giLCJpYXQiOjE3NjU2NDEyMzEsImV4cCI6MTc2NjI0NjAzMX0.mYQSxvV4A7ZQpT8c1rcl2vfSDJmyXSB6n4qsv21ym4533Wo27244md3RtXAX24XHP8JSFYjLquDi7E6eumbYRw"
  }
}
```

#### Access Token 만료 시 응답 결과
```
HTTP/1.1 401 
Content-Type: application/json;charset=UTF-8

{
  "code": "AUTH0001",
  "message": "인증이 필요합니다."
}
```