### PR TITLE
feat: #20 모임 조회 관련 API 추가

### DIFF
--- a/src/main/java/pyws/swyp/auth/service/AuthService.java
+++ b/src/main/java/pyws/swyp/auth/service/AuthService.java
@@ -11,7 +11,7 @@ import pyws.swyp.auth.dto.JwtResponse;
 import pyws.swyp.auth.dto.LoginRequest;
 import pyws.swyp.auth.dto.SignupRequest;
 import pyws.swyp.member.entity.Member;
-import pyws.swyp.member.entity.Role;
+import pyws.swyp.member.entity.MemberRole;
 import pyws.swyp.member.entity.SocialAccount;
 import pyws.swyp.member.repository.MemberRepository;
 import pyws.swyp.member.repository.SocialAccountRepository;
@@ -40,7 +40,7 @@ public class AuthService {
 
         // 기존 회원 -> JWT 발급
         Member member = socialAccountOpt.get().getMember();
-        JwtResponse tokens = jwtService.issueTokens(member.getId(), member.getRole());
+        JwtResponse tokens = jwtService.issueTokens(member.getId(), member.getMemberRole());
 
         return new AuthResponse(false, tokens);
     }
@@ -64,7 +64,7 @@ public class AuthService {
                 .nickname(request.nickname())
                 .birthDate(request.birthDate())
                 .gender(request.gender())
-                .role(Role.MEMBER)
+                .memberRole(MemberRole.MEMBER)
                 .characterType(request.characterType())
                 .build();
         memberRepository.save(member);
@@ -78,7 +78,7 @@ public class AuthService {
         socialAccountRepository.save(socialAccount);
 
         // 로그인 처리
-        JwtResponse tokens = jwtService.issueTokens(member.getId(), member.getRole());
+        JwtResponse tokens = jwtService.issueTokens(member.getId(), member.getMemberRole());
 
         return new AuthResponse(false, tokens);
     }

--- a/src/main/java/pyws/swyp/auth/service/JwtService.java
+++ b/src/main/java/pyws/swyp/auth/service/JwtService.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Service;
 import pyws.swyp.auth.dto.JwtResponse;
 import pyws.swyp.auth.repository.RefreshTokenRepository;
 import pyws.swyp.global.jwt.JwtProvider;
-import pyws.swyp.member.entity.Role;
+import pyws.swyp.member.entity.MemberRole;
 
 @Service
 @RequiredArgsConstructor
@@ -16,9 +16,9 @@ public class JwtService {
     private final JwtProvider jwtProvider;
     private final RefreshTokenRepository refreshTokenRepository;
 
-    public JwtResponse issueTokens(Long memberId, Role role) {
-        String accessToken = jwtProvider.createAccessToken(memberId, role);
-        String refreshToken = jwtProvider.createRefreshToken(memberId, role);
+    public JwtResponse issueTokens(Long memberId, MemberRole memberRole) {
+        String accessToken = jwtProvider.createAccessToken(memberId, memberRole);
+        String refreshToken = jwtProvider.createRefreshToken(memberId, memberRole);
 
         refreshTokenRepository.save(memberId, refreshToken);
 
@@ -33,7 +33,7 @@ public class JwtService {
         }
 
         Long memberId = jwtProvider.getMemberId(refreshToken);
-        Role role = jwtProvider.getRole(refreshToken);
+        MemberRole memberRole = jwtProvider.getRole(refreshToken);
 
         // Redis에 저장된 Refresh Token과 일치하는지 확인
         boolean matches = refreshTokenRepository.matches(memberId, refreshToken);
@@ -43,7 +43,7 @@ public class JwtService {
         }
 
         // 재발급하여 반환
-        return issueTokens(memberId, role);
+        return issueTokens(memberId, memberRole);
     }
 
     public void logout(Long memberId) {

--- a/src/main/java/pyws/swyp/global/jwt/JwtProvider.java
+++ b/src/main/java/pyws/swyp/global/jwt/JwtProvider.java
@@ -11,7 +11,7 @@ import java.util.Date;
 import javax.crypto.SecretKey;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
-import pyws.swyp.member.entity.Role;
+import pyws.swyp.member.entity.MemberRole;
 
 @Component
 @RequiredArgsConstructor
@@ -26,22 +26,22 @@ public class JwtProvider {
         this.key = io.jsonwebtoken.security.Keys.hmacShaKeyFor(decoded);
     }
 
-    public String createAccessToken(Long memberId, Role role) {
-        return createToken(memberId, role, "access", props.getAccessTokenTtlMs());
+    public String createAccessToken(Long memberId, MemberRole memberRole) {
+        return createToken(memberId, memberRole, "access", props.getAccessTokenTtlMs());
     }
 
-    public String createRefreshToken(Long memberId, Role role) {
-        return createToken(memberId, role, "refresh", props.getRefreshTokenTtlMs());
+    public String createRefreshToken(Long memberId, MemberRole memberRole) {
+        return createToken(memberId, memberRole, "refresh", props.getRefreshTokenTtlMs());
     }
 
-    private String createToken(Long memberId, Role role, String type, long ttlMs) {
+    private String createToken(Long memberId, MemberRole memberRole, String type, long ttlMs) {
         Instant now = Instant.now();
         Instant exp = now.plusMillis(ttlMs);
 
         return Jwts.builder()
                 .issuer(props.getIssuer())
                 .subject(String.valueOf(memberId))
-                .claim("role", role.name())
+                .claim("memberRole", memberRole.name())
                 .claim("typ", type)
                 .issuedAt(Date.from(now))
                 .expiration(Date.from(exp))
@@ -82,9 +82,9 @@ public class JwtProvider {
         return Long.parseLong(parse(token).getPayload().getSubject());
     }
 
-    public Role getRole(String token) {
+    public MemberRole getRole(String token) {
         Claims claims = parse(token).getPayload();
-        String role = claims.get("role", String.class);
-        return Role.valueOf(role);
+        String role = claims.get("memberRole", String.class);
+        return MemberRole.valueOf(role);
     }
 }

--- a/src/main/java/pyws/swyp/global/security/JwtFilter.java
+++ b/src/main/java/pyws/swyp/global/security/JwtFilter.java
@@ -8,13 +8,12 @@ import java.io.IOException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 import pyws.swyp.global.jwt.JwtProvider;
-import pyws.swyp.member.entity.Role;
+import pyws.swyp.member.entity.MemberRole;
 
 @Component
 @RequiredArgsConstructor
@@ -41,9 +40,9 @@ public class JwtFilter extends OncePerRequestFilter {
         Boolean isAccessToken = jwtProvider.validateToken(accessToken, true);
         if (isAccessToken) {
             Long memberId = jwtProvider.getMemberId(accessToken);
-            Role role = jwtProvider.getRole(accessToken);
+            MemberRole memberRole = jwtProvider.getRole(accessToken);
 
-            var authority = new SimpleGrantedAuthority("ROLE_" + role.name());
+            var authority = new SimpleGrantedAuthority("ROLE_" + memberRole.name());
             var auth = new UsernamePasswordAuthenticationToken(memberId, null, List.of(authority));
             SecurityContextHolder.getContext().setAuthentication(auth);
         } else {

--- a/src/main/java/pyws/swyp/meeting/controller/HomeController.java
+++ b/src/main/java/pyws/swyp/meeting/controller/HomeController.java
@@ -1,0 +1,23 @@
+package pyws.swyp.meeting.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import pyws.swyp.meeting.controller.api.HomeApi;
+import pyws.swyp.meeting.dto.HomeResponse;
+import pyws.swyp.meeting.service.HomeService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/home")
+public class HomeController implements HomeApi {
+
+    private final HomeService homeService;
+
+    @GetMapping
+    public HomeResponse getHomeInfo(@AuthenticationPrincipal Long memberId) {
+        return homeService.getHomeInfo(memberId);
+    }
+}

--- a/src/main/java/pyws/swyp/meeting/controller/MeetingController.java
+++ b/src/main/java/pyws/swyp/meeting/controller/MeetingController.java
@@ -26,7 +26,7 @@ public class MeetingController implements MeetingApi {
         meetingService.deleteMeeting(memberId, id);
     }
 
-    @DeleteMapping("quit/{id}")
+    @DeleteMapping("/quit/{id}")
     public void quitMeeting(@AuthenticationPrincipal Long memberId, @PathVariable Long id) {
         meetingService.quitMeeting(memberId, id);
     }

--- a/src/main/java/pyws/swyp/meeting/controller/MeetingController.java
+++ b/src/main/java/pyws/swyp/meeting/controller/MeetingController.java
@@ -1,13 +1,18 @@
 package pyws.swyp.meeting.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import pyws.swyp.meeting.controller.api.MeetingApi;
+import pyws.swyp.meeting.dto.MeetingBriefResponse;
 import pyws.swyp.meeting.dto.MeetingCreateRequest;
 import pyws.swyp.meeting.dto.MeetingUpdateRequest;
 import pyws.swyp.meeting.service.MeetingService;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -38,5 +43,15 @@ public class MeetingController implements MeetingApi {
             @RequestBody MeetingUpdateRequest request
     ) {
         meetingService.updateMeeting(memberId, id, request);
+    }
+
+    @GetMapping("/all")
+    public List<MeetingBriefResponse> getAllMeetings(@AuthenticationPrincipal Long memberId) {
+        return meetingService.getAllMeetings(memberId);
+    }
+
+    @GetMapping("/waiting")
+    public List<MeetingBriefResponse> getWaitingMeetings(@AuthenticationPrincipal Long memberId, @PageableDefault Pageable pageable) {
+        return meetingService.getWaitingMeetings(memberId, pageable);
     }
 }

--- a/src/main/java/pyws/swyp/meeting/controller/api/HomeApi.java
+++ b/src/main/java/pyws/swyp/meeting/controller/api/HomeApi.java
@@ -1,0 +1,28 @@
+package pyws.swyp.meeting.controller.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import pyws.swyp.meeting.dto.HomeResponse;
+
+@SecurityRequirement(name = "auth")
+@Tag(name = "Home API")
+public interface HomeApi {
+    @Operation(
+            summary = "홈 화면 조회",
+            description =
+                    """
+                            홈 화면 조회에 필요한 데이터를 제공합니다.
+                            7일 이내 예정된 모임 리스트 날짜 오름차순 조회
+                            대기 중인 모임 리스트 최대 3개 조회
+                    """
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "홈 화면 조회 성공"
+    )
+    HomeResponse getHomeInfo(@AuthenticationPrincipal Long memberId);
+
+}

--- a/src/main/java/pyws/swyp/meeting/controller/api/MeetingApi.java
+++ b/src/main/java/pyws/swyp/meeting/controller/api/MeetingApi.java
@@ -4,14 +4,17 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import pyws.swyp.meeting.dto.MeetingBriefResponse;
 import pyws.swyp.meeting.dto.MeetingCreateRequest;
 import pyws.swyp.meeting.dto.MeetingUpdateRequest;
+
+import java.util.List;
 
 @SecurityRequirement(name = "auth")
 @Tag(name = "Meeting API")
@@ -77,4 +80,32 @@ public interface MeetingApi {
             @PathVariable Long id,
             @RequestBody MeetingUpdateRequest request
     );
+
+    @Operation(
+            summary = "전체 모임 리스트 조회",
+            description =
+                    """
+                            캘린더뷰에서 필요한 전체 모임 리스트 조회 요청을 처리합니다.
+                            본인이 속한 모임들에 대한 brief 모임 정보를 가져옵니다.
+                    """
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "전체 모임 리스트 조회 성공"
+    )
+    List<MeetingBriefResponse> getAllMeetings(@AuthenticationPrincipal Long memberId);
+
+    @Operation(
+            summary = "기다리고 있는 모임 리스트 조회",
+            description =
+                    """
+                            "친구들이 기다려요" -> 더보기 클릭 시 요청한 모임 리스트 조회를 처리합니다.
+                            Meeting.Status의 값이 CREATED, DATE_VOTING, PLACE_VOTING인 경우만 반환합니다.
+                    """
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "전체 모임 리스트 조회 성공"
+    )
+    List<MeetingBriefResponse> getWaitingMeetings(@AuthenticationPrincipal Long memberId, @PageableDefault Pageable pageable);
 }

--- a/src/main/java/pyws/swyp/meeting/dto/HomeResponse.java
+++ b/src/main/java/pyws/swyp/meeting/dto/HomeResponse.java
@@ -1,0 +1,9 @@
+package pyws.swyp.meeting.dto;
+
+import java.util.List;
+
+public record HomeResponse(
+        List<MeetingBriefWithParticipantsResponse> homeMeetings,
+        List<MeetingBriefResponse> waitingMeetings
+) {
+}

--- a/src/main/java/pyws/swyp/meeting/dto/MeetingBriefResponse.java
+++ b/src/main/java/pyws/swyp/meeting/dto/MeetingBriefResponse.java
@@ -1,0 +1,13 @@
+package pyws.swyp.meeting.dto;
+
+import pyws.swyp.meeting.entity.Status;
+
+import java.time.LocalDateTime;
+
+public record MeetingBriefResponse(
+        Long meetingId,
+        String title,
+        Status status,
+        LocalDateTime date
+) {
+}

--- a/src/main/java/pyws/swyp/meeting/dto/MeetingBriefWithParticipantsResponse.java
+++ b/src/main/java/pyws/swyp/meeting/dto/MeetingBriefWithParticipantsResponse.java
@@ -3,11 +3,13 @@ package pyws.swyp.meeting.dto;
 import pyws.swyp.meeting.entity.Status;
 
 import java.time.LocalDate;
+import java.util.List;
 
-public record MeetingBriefResponse(
+public record MeetingBriefWithParticipantsResponse(
         Long meetingId,
         String title,
         Status status,
-        LocalDate date
+        LocalDate date,
+        List<ParticipantResponse> participants
 ) {
 }

--- a/src/main/java/pyws/swyp/meeting/dto/MeetingCreateRequest.java
+++ b/src/main/java/pyws/swyp/meeting/dto/MeetingCreateRequest.java
@@ -4,12 +4,13 @@ package pyws.swyp.meeting.dto;
 import jakarta.validation.constraints.NotBlank;
 import pyws.swyp.meeting.entity.Meeting;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 public record MeetingCreateRequest(
         @NotBlank(message = "모임명을 입력해주세요")
         String title,
-        LocalDateTime date,
+        LocalDate date,
         LocalDateTime dateVoteDeadline,
         LocalDateTime courseVoteDeadline
 ) {

--- a/src/main/java/pyws/swyp/meeting/dto/MeetingUpdateRequest.java
+++ b/src/main/java/pyws/swyp/meeting/dto/MeetingUpdateRequest.java
@@ -1,10 +1,11 @@
 package pyws.swyp.meeting.dto;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 public record MeetingUpdateRequest(
         String title,
-        LocalDateTime date,
+        LocalDate date,
         LocalDateTime dateVoteDeadline,
         LocalDateTime courseVoteDeadline
 ) {

--- a/src/main/java/pyws/swyp/meeting/dto/ParticipantResponse.java
+++ b/src/main/java/pyws/swyp/meeting/dto/ParticipantResponse.java
@@ -1,0 +1,12 @@
+package pyws.swyp.meeting.dto;
+
+import pyws.swyp.meeting.entity.Role;
+import pyws.swyp.member.entity.CharacterType;
+
+public record ParticipantResponse(
+        Long memberId,
+        String nickname,
+        CharacterType characterType,
+        Role meetingRole
+) {
+}

--- a/src/main/java/pyws/swyp/meeting/dto/ParticipantResponse.java
+++ b/src/main/java/pyws/swyp/meeting/dto/ParticipantResponse.java
@@ -1,12 +1,12 @@
 package pyws.swyp.meeting.dto;
 
-import pyws.swyp.meeting.entity.Role;
+import pyws.swyp.meeting.entity.ParticipantRole;
 import pyws.swyp.member.entity.CharacterType;
 
 public record ParticipantResponse(
         Long memberId,
         String nickname,
         CharacterType characterType,
-        Role meetingRole
+        ParticipantRole meetingParticipantRole
 ) {
 }

--- a/src/main/java/pyws/swyp/meeting/dto/ParticipantRow.java
+++ b/src/main/java/pyws/swyp/meeting/dto/ParticipantRow.java
@@ -1,0 +1,4 @@
+package pyws.swyp.meeting.dto;
+
+public record ParticipantRow(Long meetingId, ParticipantResponse participant) {
+}

--- a/src/main/java/pyws/swyp/meeting/entity/Meeting.java
+++ b/src/main/java/pyws/swyp/meeting/entity/Meeting.java
@@ -48,10 +48,6 @@ public class Meeting extends BaseEntity {
         this.courseVoteDeadline = courseVoteDeadline;
     }
 
-    public void updateStatus(String status) {
-        this.status = Status.valueOf(status);
-    }
-
     public void update(MeetingUpdateRequest request) {
         if (request.title() != null) {
             if(request.title().isBlank()) {

--- a/src/main/java/pyws/swyp/meeting/entity/Meeting.java
+++ b/src/main/java/pyws/swyp/meeting/entity/Meeting.java
@@ -12,7 +12,9 @@ import pyws.swyp.global.entity.BaseEntity;
 import pyws.swyp.global.error.ErrorCode;
 import pyws.swyp.meeting.dto.MeetingUpdateRequest;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 
 @Entity
 @Getter
@@ -23,7 +25,10 @@ public class Meeting extends BaseEntity {
     private String title;
 
     @Column
-    private LocalDateTime date;
+    private LocalDate date;
+
+    @Column
+    private LocalTime time;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
@@ -38,12 +43,14 @@ public class Meeting extends BaseEntity {
     @Builder
     public Meeting(
             String title,
-            LocalDateTime date,
+            LocalDate date,
+            LocalTime time,
             LocalDateTime dateVoteDeadline,
             LocalDateTime courseVoteDeadline
     ) {
         this.title = title;
         this.date = date;
+        this.time = time;
         this.dateVoteDeadline = dateVoteDeadline;
         this.courseVoteDeadline = courseVoteDeadline;
     }

--- a/src/main/java/pyws/swyp/meeting/entity/MeetingParticipant.java
+++ b/src/main/java/pyws/swyp/meeting/entity/MeetingParticipant.java
@@ -20,20 +20,20 @@ public class MeetingParticipant extends BaseEntity {
     
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 30)
-    private Role role;
+    private ParticipantRole participantRole;
 
     @Builder
-    public MeetingParticipant(Meeting meeting, Member member, Role role) {
+    public MeetingParticipant(Meeting meeting, Member member, ParticipantRole participantRole) {
         this.meeting = meeting;
         this.member = member;
-        this.role = role;
+        this.participantRole = participantRole;
     }
 
     public static MeetingParticipant host(Meeting meeting, Member member) {
         return MeetingParticipant.builder()
                 .meeting(meeting)
                 .member(member)
-                .role(Role.HOST)
+                .participantRole(pyws.swyp.meeting.entity.ParticipantRole.HOST)
                 .build();
     }
 }

--- a/src/main/java/pyws/swyp/meeting/entity/ParticipantRole.java
+++ b/src/main/java/pyws/swyp/meeting/entity/ParticipantRole.java
@@ -1,6 +1,6 @@
 package pyws.swyp.meeting.entity;
 
-public enum Role {
+public enum ParticipantRole {
 
     HOST, MEMBER
 }

--- a/src/main/java/pyws/swyp/meeting/entity/Status.java
+++ b/src/main/java/pyws/swyp/meeting/entity/Status.java
@@ -8,9 +8,10 @@ import lombok.RequiredArgsConstructor;
 public enum Status {
 
     CREATED(1),
-    VOTING(2),
-    FIXED(3),
-    DONE(4),
+    DATE_VOTING(2),
+    PLACE_VOTING(3),
+    FIXED(4),
+    DONE(5),
     ;
 
     private final int level;

--- a/src/main/java/pyws/swyp/meeting/repository/MeetingParticipantRepository.java
+++ b/src/main/java/pyws/swyp/meeting/repository/MeetingParticipantRepository.java
@@ -76,7 +76,7 @@ public interface MeetingParticipantRepository extends JpaRepository<MeetingParti
                             mp.member.id,
                             mp.member.nickname,
                             mp.member.characterType,
-                            mp.role
+                            mp.participantRole
                         )
             )
             FROM MeetingParticipant mp

--- a/src/main/java/pyws/swyp/meeting/repository/MeetingParticipantRepository.java
+++ b/src/main/java/pyws/swyp/meeting/repository/MeetingParticipantRepository.java
@@ -1,12 +1,51 @@
 package pyws.swyp.meeting.repository;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import pyws.swyp.meeting.dto.MeetingBriefResponse;
 import pyws.swyp.meeting.entity.MeetingParticipant;
+import pyws.swyp.meeting.entity.Status;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 public interface MeetingParticipantRepository extends JpaRepository<MeetingParticipant, Long> {
 
     Optional<MeetingParticipant> findByMemberIdAndMeetingId(Long memberId, Long meetingId);
+
+    @Query("""
+            SELECT new pyws.swyp.meeting.dto.MeetingBriefResponse(
+                        mp.meeting.id,
+                        mp.meeting.title,
+                        mp.meeting.status,
+                        mp.meeting.date
+            )
+            FROM MeetingParticipant mp
+            WHERE mp.member.id = :memberId
+            ORDER BY CASE WHEN mp.meeting.date IS NULL THEN 1 ELSE 0 END, mp.meeting.date ASC
+    """)
+    List<MeetingBriefResponse> findByMemberId(@Param("memberId") Long memberId);
+
+    @Query("""
+            SELECT new pyws.swyp.meeting.dto.MeetingBriefResponse(
+                        m.id,
+                        m.title,
+                        m.status,
+                        m.date
+            )
+            FROM MeetingParticipant mp
+            JOIN mp.meeting m
+            WHERE mp.member.id = :memberId
+                AND m.status IN :statuses
+            ORDER BY CASE WHEN m.date IS NULL THEN 1 ELSE 0 END, m.date ASC
+    """)
+    List<MeetingBriefResponse> findByMemberIdAndStatus(
+            @Param("memberId") Long memberId,
+            @Param("statuses")Collection<Status> statuses,
+            Pageable pageable
+    );
 
 }

--- a/src/main/java/pyws/swyp/meeting/repository/MeetingParticipantRepository.java
+++ b/src/main/java/pyws/swyp/meeting/repository/MeetingParticipantRepository.java
@@ -5,9 +5,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import pyws.swyp.meeting.dto.MeetingBriefResponse;
+import pyws.swyp.meeting.dto.ParticipantRow;
 import pyws.swyp.meeting.entity.MeetingParticipant;
 import pyws.swyp.meeting.entity.Status;
 
+import java.time.LocalDate;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -27,7 +29,7 @@ public interface MeetingParticipantRepository extends JpaRepository<MeetingParti
             WHERE mp.member.id = :memberId
             ORDER BY CASE WHEN mp.meeting.date IS NULL THEN 1 ELSE 0 END, mp.meeting.date ASC
     """)
-    List<MeetingBriefResponse> findByMemberId(@Param("memberId") Long memberId);
+    List<MeetingBriefResponse> findMeetingsByMemberId(@Param("memberId") Long memberId);
 
     @Query("""
             SELECT new pyws.swyp.meeting.dto.MeetingBriefResponse(
@@ -42,10 +44,43 @@ public interface MeetingParticipantRepository extends JpaRepository<MeetingParti
                 AND m.status IN :statuses
             ORDER BY CASE WHEN m.date IS NULL THEN 1 ELSE 0 END, m.date ASC
     """)
-    List<MeetingBriefResponse> findByMemberIdAndStatus(
+    List<MeetingBriefResponse> findMeetingsByMemberIdAndStatus(
             @Param("memberId") Long memberId,
             @Param("statuses")Collection<Status> statuses,
             Pageable pageable
     );
 
+    @Query("""
+            SELECT new pyws.swyp.meeting.dto.MeetingBriefResponse(
+                        m.id,
+                        m.title,
+                        m.status,
+                        m.date
+            )
+            FROM MeetingParticipant mp
+            JOIN mp.meeting m
+            WHERE mp.member.id = :memberId
+                AND m.date BETWEEN :now AND :endDate
+            ORDER BY m.date ASC
+    """)
+    List<MeetingBriefResponse> findMeetingsByMemberIdWithin7Days(
+            @Param("memberId") Long memberId,
+            @Param("now") LocalDate now,
+            @Param("endDate") LocalDate endDate
+    );
+
+    @Query("""
+            SELECT new pyws.swyp.meeting.dto.ParticipantRow(
+                        mp.meeting.id,
+                        new pyws.swyp.meeting.dto.ParticipantResponse(
+                            mp.member.id,
+                            mp.member.nickname,
+                            mp.member.characterType,
+                            mp.role
+                        )
+            )
+            FROM MeetingParticipant mp
+            WHERE mp.meeting.id IN :meetingIds
+    """)
+    List<ParticipantRow> findByMeetingIds(@Param("meetingIds") List<Long> meetingIds);
 }

--- a/src/main/java/pyws/swyp/meeting/service/HomeService.java
+++ b/src/main/java/pyws/swyp/meeting/service/HomeService.java
@@ -1,0 +1,63 @@
+package pyws.swyp.meeting.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import pyws.swyp.meeting.dto.*;
+import pyws.swyp.meeting.entity.Status;
+import pyws.swyp.meeting.repository.MeetingParticipantRepository;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class HomeService {
+
+    private final MeetingParticipantRepository meetingParticipantRepository;
+
+    private static final int DEFAULT_TOP = 3;
+
+    @Transactional(readOnly = true)
+    public HomeResponse getHomeInfo(Long memberId) {
+        // 홈 상단 예정된 일정 카드
+        LocalDate now = LocalDate.now(ZoneId.of("Asia/Seoul"));
+        LocalDate endDate = now.plusDays(7);
+        List<MeetingBriefResponse> meetingInfos = meetingParticipantRepository.findMeetingsByMemberIdWithin7Days(memberId, now, endDate);
+
+        List<Long> meetingIds = meetingInfos.stream()
+                .map(MeetingBriefResponse::meetingId)
+                .toList();
+
+        Map<Long, List<ParticipantResponse>> participants
+                = meetingIds.isEmpty() ? Map.of()
+                : meetingParticipantRepository.findByMeetingIds(meetingIds).stream()
+                .collect(Collectors.groupingBy(
+                        ParticipantRow::meetingId,
+                        Collectors.mapping(ParticipantRow::participant, Collectors.toList())
+                ));
+
+        List<MeetingBriefWithParticipantsResponse> upcomingMeetings =
+                meetingInfos.stream()
+                        .map(info -> new MeetingBriefWithParticipantsResponse(
+                                info.meetingId(),
+                                info.title(),
+                                info.status(),
+                                info.date(),
+                                participants.getOrDefault(info.meetingId(), List.of())
+                        ))
+                        .toList();
+
+        // 홈 하단 기다리고 있는 일정 카드
+        List<Status> statuses = List.of(Status.CREATED, Status.DATE_VOTING, Status.PLACE_VOTING);
+        List<MeetingBriefResponse> waitingMeetings
+                = meetingParticipantRepository.findMeetingsByMemberIdAndStatus(
+                        memberId, statuses, PageRequest.of(0, DEFAULT_TOP));
+
+        return new HomeResponse(upcomingMeetings, waitingMeetings);
+    }
+}

--- a/src/main/java/pyws/swyp/meeting/service/MeetingService.java
+++ b/src/main/java/pyws/swyp/meeting/service/MeetingService.java
@@ -1,19 +1,24 @@
 package pyws.swyp.meeting.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import pyws.swyp.global.error.CustomException;
 import pyws.swyp.global.error.ErrorCode;
+import pyws.swyp.meeting.dto.MeetingBriefResponse;
 import pyws.swyp.meeting.dto.MeetingCreateRequest;
 import pyws.swyp.meeting.dto.MeetingUpdateRequest;
 import pyws.swyp.meeting.entity.Meeting;
 import pyws.swyp.meeting.entity.MeetingParticipant;
 import pyws.swyp.meeting.entity.Role;
+import pyws.swyp.meeting.entity.Status;
 import pyws.swyp.meeting.repository.MeetingParticipantRepository;
 import pyws.swyp.meeting.repository.MeetingRepository;
 import pyws.swyp.member.entity.Member;
 import pyws.swyp.member.repository.MemberRepository;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -63,6 +68,15 @@ public class MeetingService {
         validateMeetingParticipant(memberId, meetingId);
 
         meeting.update(request);
+    }
+
+    public List<MeetingBriefResponse> getAllMeetings(Long memberId) {
+        return meetingParticipantRepository.findByMemberId(memberId);
+    }
+
+    public List<MeetingBriefResponse> getWaitingMeetings(Long memberId, Pageable pageable) {
+        List<Status> statuses = List.of(Status.CREATED, Status.DATE_VOTING, Status.PLACE_VOTING);
+        return meetingParticipantRepository.findByMemberIdAndStatus(memberId, statuses, pageable);
     }
 
     private Meeting validActiveMeeting(Long meetingId) {

--- a/src/main/java/pyws/swyp/meeting/service/MeetingService.java
+++ b/src/main/java/pyws/swyp/meeting/service/MeetingService.java
@@ -71,12 +71,12 @@ public class MeetingService {
     }
 
     public List<MeetingBriefResponse> getAllMeetings(Long memberId) {
-        return meetingParticipantRepository.findByMemberId(memberId);
+        return meetingParticipantRepository.findMeetingsByMemberId(memberId);
     }
 
     public List<MeetingBriefResponse> getWaitingMeetings(Long memberId, Pageable pageable) {
         List<Status> statuses = List.of(Status.CREATED, Status.DATE_VOTING, Status.PLACE_VOTING);
-        return meetingParticipantRepository.findByMemberIdAndStatus(memberId, statuses, pageable);
+        return meetingParticipantRepository.findMeetingsByMemberIdAndStatus(memberId, statuses, pageable);
     }
 
     private Meeting validActiveMeeting(Long meetingId) {

--- a/src/main/java/pyws/swyp/meeting/service/MeetingService.java
+++ b/src/main/java/pyws/swyp/meeting/service/MeetingService.java
@@ -11,7 +11,7 @@ import pyws.swyp.meeting.dto.MeetingCreateRequest;
 import pyws.swyp.meeting.dto.MeetingUpdateRequest;
 import pyws.swyp.meeting.entity.Meeting;
 import pyws.swyp.meeting.entity.MeetingParticipant;
-import pyws.swyp.meeting.entity.Role;
+import pyws.swyp.meeting.entity.ParticipantRole;
 import pyws.swyp.meeting.entity.Status;
 import pyws.swyp.meeting.repository.MeetingParticipantRepository;
 import pyws.swyp.meeting.repository.MeetingRepository;
@@ -45,7 +45,7 @@ public class MeetingService {
         Meeting meeting = validActiveMeeting(meetingId);
 
         MeetingParticipant participant = validateMeetingParticipant(memberId, meetingId);
-        if(participant.getRole() != Role.HOST) {
+        if(participant.getParticipantRole() != pyws.swyp.meeting.entity.ParticipantRole.HOST) {
             throw ErrorCode.MEETING_ACCESS_DENIED.toException();
         }
 
@@ -56,7 +56,7 @@ public class MeetingService {
         validActiveMeeting(meetingId);
 
         MeetingParticipant participant = validateMeetingParticipant(memberId, meetingId);
-        if(participant.getRole() != Role.MEMBER) {
+        if(participant.getParticipantRole() != ParticipantRole.MEMBER) {
             throw ErrorCode.MEETING_QUIT_DENIED.toException();
         }
 
@@ -70,10 +70,12 @@ public class MeetingService {
         meeting.update(request);
     }
 
+    @Transactional(readOnly = true)
     public List<MeetingBriefResponse> getAllMeetings(Long memberId) {
         return meetingParticipantRepository.findMeetingsByMemberId(memberId);
     }
 
+    @Transactional(readOnly = true)
     public List<MeetingBriefResponse> getWaitingMeetings(Long memberId, Pageable pageable) {
         List<Status> statuses = List.of(Status.CREATED, Status.DATE_VOTING, Status.PLACE_VOTING);
         return meetingParticipantRepository.findMeetingsByMemberIdAndStatus(memberId, statuses, pageable);

--- a/src/main/java/pyws/swyp/member/dto/MemberResponse.java
+++ b/src/main/java/pyws/swyp/member/dto/MemberResponse.java
@@ -4,14 +4,14 @@ import java.time.LocalDate;
 import java.util.List;
 import pyws.swyp.member.entity.CharacterType;
 import pyws.swyp.member.entity.Gender;
-import pyws.swyp.member.entity.Role;
+import pyws.swyp.member.entity.MemberRole;
 
 public record MemberResponse(
         String email,
         String nickname,
         LocalDate birthDate,
         Gender gender,
-        Role role,
+        MemberRole memberRole,
         CharacterType characterType,
         List<SocialAccountInfo> socialAccounts
 ) {

--- a/src/main/java/pyws/swyp/member/entity/Member.java
+++ b/src/main/java/pyws/swyp/member/entity/Member.java
@@ -40,7 +40,7 @@ public class Member {
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 50)
-    private Role role;
+    private MemberRole memberRole;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 50)
@@ -54,12 +54,12 @@ public class Member {
     private LocalDateTime updatedAt;
 
     @Builder
-    public Member(String email, String nickname, LocalDate birthDate, Gender gender, Role role, CharacterType characterType) {
+    public Member(String email, String nickname, LocalDate birthDate, Gender gender, MemberRole memberRole, CharacterType characterType) {
         this.email = email;
         this.nickname = nickname;
         this.birthDate = birthDate;
         this.gender = gender;
-        this.role = role;
+        this.memberRole = memberRole;
         this.characterType = characterType;
     }
 

--- a/src/main/java/pyws/swyp/member/entity/MemberRole.java
+++ b/src/main/java/pyws/swyp/member/entity/MemberRole.java
@@ -1,5 +1,5 @@
 package pyws.swyp.member.entity;
 
-public enum Role {
+public enum MemberRole {
     ADMIN, MEMBER;
 }

--- a/src/main/java/pyws/swyp/member/service/MemberService.java
+++ b/src/main/java/pyws/swyp/member/service/MemberService.java
@@ -42,7 +42,7 @@ public class MemberService {
                 member.getNickname(),
                 member.getBirthDate(),
                 member.getGender(),
-                member.getRole(),
+                member.getMemberRole(),
                 member.getCharacterType(),
                 socialAccounts
         );

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -67,7 +67,7 @@ SET FOREIGN_KEY_CHECKS = 0;
 --     created_at DATETIME(6)             NOT NULL,
 --     is_active  BIT                     NOT NULL,
 --     updated_at DATETIME(6)             NULL,
---     role       ENUM ('HOST', 'MEMBER') NOT NULL,
+--     participantRole       ENUM ('HOST', 'MEMBER') NOT NULL,
 --     meeting_id BIGINT                  NOT NULL,
 --     member_id  BIGINT                  NOT NULL,
 --     CONSTRAINT fk_meeting_participant_member
@@ -143,7 +143,7 @@ VALUES
     (1, NOW(), 'KAKAO', 'existing-social-id-123', 4);
 
 -- MEETING_PARTICIPANT
-INSERT IGNORE INTO meeting_participant (id, created_at, is_active, updated_at, role, meeting_id, member_id)
+INSERT IGNORE INTO meeting_participant (id, created_at, is_active, updated_at, participant_role, meeting_id, member_id)
 VALUES
     (1, NOW(), 1, NULL, 'HOST',   1, 1),
     (2, NOW(), 1, NULL, 'MEMBER', 1, 2),

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -124,10 +124,10 @@ SET FOREIGN_KEY_CHECKS = 0;
 ------------------------------------------------------
 
 -- MEETING
-INSERT IGNORE INTO meeting (id, created_at, is_active, updated_at, date, status, title)
+INSERT IGNORE INTO meeting (id, created_at, is_active, updated_at, date, time, status, title)
 VALUES
-    (1, NOW(), 1, NULL, '2025-12-20 18:00:00', 'CREATED', '연말 모임'),
-    (2, NOW(), 1, NULL, '2025-12-25 19:00:00', 'PLACE_VOTING', '크리스마스 모임');
+    (1, NOW(), 1, NULL, '2025-12-20', NULL, 'CREATED', '연말 모임'),
+    (2, NOW(), 1, NULL, '2025-12-25', '19:00:00', 'PLACE_VOTING', '크리스마스 모임');
 
 -- MEMBER
 INSERT IGNORE INTO member (id, created_at, birth_date, email, gender, nickname, character_type)

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -127,7 +127,7 @@ SET FOREIGN_KEY_CHECKS = 0;
 INSERT IGNORE INTO meeting (id, created_at, is_active, updated_at, date, status, title)
 VALUES
     (1, NOW(), 1, NULL, '2025-12-20 18:00:00', 'CREATED', '연말 모임'),
-    (2, NOW(), 1, NULL, '2025-12-25 19:00:00', 'VOTING', '크리스마스 모임');
+    (2, NOW(), 1, NULL, '2025-12-25 19:00:00', 'PLACE_VOTING', '크리스마스 모임');
 
 -- MEMBER
 INSERT IGNORE INTO member (id, created_at, birth_date, email, gender, nickname, character_type)

--- a/src/test/java/pyws/swyp/meeting/controller/HomeControllerTest.java
+++ b/src/test/java/pyws/swyp/meeting/controller/HomeControllerTest.java
@@ -1,0 +1,65 @@
+package pyws.swyp.meeting.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.TestConstructor;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import pyws.swyp.config.AuthPrincipalTestConfig;
+import pyws.swyp.config.AuthTestPrincipalContext;
+import pyws.swyp.global.jwt.JwtProvider;
+import pyws.swyp.meeting.service.HomeService;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(HomeController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+@Import({AuthPrincipalTestConfig.class})
+@RequiredArgsConstructor
+public class HomeControllerTest {
+    private final MockMvc mockMvc;
+
+    @MockitoBean
+    HomeService homeService;
+
+    @MockitoBean
+    JwtProvider jwtProvider;
+
+    ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+
+    @Test
+    @DisplayName("홈 화면 조회 성공")
+    void 홈화면_조회_성공() throws Exception {
+        // given
+        Long memberId = 1L;
+        AuthTestPrincipalContext.setMemberId(memberId);
+
+        // when
+        MvcResult mvcResult = mockMvc.perform(get("/api/home"))
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andReturn();
+
+        // then
+        verify(homeService, times(1)).getHomeInfo(eq(memberId));
+        Integer status = mvcResult.getResponse().getStatus();
+        assertThat(status).isEqualTo(HttpStatus.OK.value());
+    }
+}

--- a/src/test/java/pyws/swyp/meeting/controller/MeetingControllerTest.java
+++ b/src/test/java/pyws/swyp/meeting/controller/MeetingControllerTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.TestConstructor;
@@ -237,5 +238,43 @@ public class MeetingControllerTest {
         verifyNoInteractions(meetingService);
         Integer status = mvcResult.getResponse().getStatus();
         assertThat(status).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    }
+
+    @Test
+    @DisplayName("정상 요청 시 전체 모임 조회 성공")
+    void 전체_모임_조회_성공() throws Exception {
+        // given
+        Long memberId = 1L;
+        AuthTestPrincipalContext.setMemberId(memberId);
+
+        // when
+        MvcResult mvcResult = mockMvc.perform(get("/api/meetings/all"))
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andReturn();
+
+        // then
+        verify(meetingService, times(1)).getAllMeetings(memberId);
+        Integer status = mvcResult.getResponse().getStatus();
+        assertThat(status).isEqualTo(HttpStatus.OK.value());
+    }
+
+    @Test
+    @DisplayName("정상 요청 시 기다리고 있는 모임 조회 성공")
+    void 기다리고_있는_모임_조회_성공() throws Exception {
+        // given
+        Long memberId = 1L;
+        AuthTestPrincipalContext.setMemberId(memberId);
+
+        // when
+        MvcResult mvcResult = mockMvc.perform(get("/api/meetings/waiting"))
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andReturn();
+
+        // then
+        verify(meetingService, times(1)).getWaitingMeetings(eq(memberId), any(Pageable.class));
+        Integer status = mvcResult.getResponse().getStatus();
+        assertThat(status).isEqualTo(HttpStatus.OK.value());
     }
 }

--- a/src/test/java/pyws/swyp/meeting/controller/MeetingControllerTest.java
+++ b/src/test/java/pyws/swyp/meeting/controller/MeetingControllerTest.java
@@ -22,6 +22,7 @@ import pyws.swyp.meeting.dto.MeetingCreateRequest;
 import pyws.swyp.meeting.dto.MeetingUpdateRequest;
 import pyws.swyp.meeting.service.MeetingService;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -56,7 +57,7 @@ public class MeetingControllerTest {
 
         MeetingCreateRequest request = new MeetingCreateRequest(
                 "모잇 오프라인",
-                LocalDateTime.of(2025,12,30,14,0),
+                LocalDate.of(2025,12,30),
                 LocalDateTime.of(2025,12,15,23,59),
                 LocalDateTime.of(2025,12,26,23,59)
         );
@@ -82,7 +83,7 @@ public class MeetingControllerTest {
         // given
         MeetingCreateRequest request = new MeetingCreateRequest(
                 "  ",
-                LocalDateTime.of(2025,12,30,14,0),
+                LocalDate.of(2025,12,30),
                 LocalDateTime.of(2025,12,15,23,59),
                 LocalDateTime.of(2025,12,26,23,59)
         );
@@ -191,7 +192,7 @@ public class MeetingControllerTest {
 
         MeetingUpdateRequest request = new MeetingUpdateRequest(
                 "모잇 오프라인",
-                LocalDateTime.of(2025,12,30,14,0),
+                LocalDate.of(2025,12,30),
                 LocalDateTime.of(2025,12,15,23,59),
                 LocalDateTime.of(2025,12,26,23,59)
         );
@@ -220,7 +221,7 @@ public class MeetingControllerTest {
 
         MeetingUpdateRequest request = new MeetingUpdateRequest(
                 "모잇 오프라인",
-                LocalDateTime.of(2025,12,30,14,0),
+                LocalDate.of(2025,12,30),
                 LocalDateTime.of(2025,12,15,23,59),
                 LocalDateTime.of(2025,12,26,23,59)
         );

--- a/src/test/java/pyws/swyp/meeting/controller/MeetingControllerTest.java
+++ b/src/test/java/pyws/swyp/meeting/controller/MeetingControllerTest.java
@@ -7,26 +7,32 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.TestConstructor;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
+import pyws.swyp.config.AuthPrincipalTestConfig;
+import pyws.swyp.config.AuthTestPrincipalContext;
+import pyws.swyp.global.jwt.JwtProvider;
 import pyws.swyp.meeting.dto.MeetingCreateRequest;
+import pyws.swyp.meeting.dto.MeetingUpdateRequest;
 import pyws.swyp.meeting.service.MeetingService;
 
 import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(MeetingController.class)
 @AutoConfigureMockMvc(addFilters = false)
 @TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+@Import({AuthPrincipalTestConfig.class})
 @RequiredArgsConstructor
 public class MeetingControllerTest {
 
@@ -35,86 +41,201 @@ public class MeetingControllerTest {
     @MockitoBean
     MeetingService meetingService;
 
+    @MockitoBean
+    JwtProvider jwtProvider;
+
     ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
 
-    // Todo: jwtFilter 관련 테스트 문제 해결 후 수정 예정.
+    @Test
+    @DisplayName("정상 요청 시 모임 생성 성공")
+    void 모임_생성_성공() throws Exception{
+        // given
+        Long memberId = 1L;
+        AuthTestPrincipalContext.setMemberId(memberId);
 
-//    @Test
-//    @DisplayName("정상 요청 시 모임 생성 성공")
-//    void 모임_생성_성공() throws Exception{
-//        // given
-//        Long memberId = 1L;
-//
-//        MeetingCreateRequest request = new MeetingCreateRequest(
-//                "모잇 오프라인",
-//                LocalDateTime.of(2025,12,30,14,0),
-//                LocalDateTime.of(2025,12,15,23,59),
-//                LocalDateTime.of(2025,12,26,23,59)
-//        );
-//
-//        // when
-//        MvcResult mvcResult = mockMvc.perform(post("/api/meetings")
-//                .contentType(MediaType.APPLICATION_JSON)
-//                .content(objectMapper.writeValueAsString(request))
-//                )
-//                .andExpect(status().isOk())
-//                .andDo(print())
-//                .andReturn();
-//
-//        // then
-//        verify(meetingService, times(1)).createMeeting(memberId, request);
-//        Integer status = mvcResult.getResponse().getStatus();
-//        assertThat(status).isEqualTo(HttpStatus.OK.value());
-//    }
-//
-//    @Test
-//    @DisplayName("모임 이름 Blank일 시 생성 실패")
-//    void 모임_생성_실패_모임_이름_blank() throws Exception{
-//        // given
-//        MeetingCreateRequest request = new MeetingCreateRequest(
-//                "  ",
-//                LocalDateTime.of(2025,12,30,14,0),
-//                LocalDateTime.of(2025,12,15,23,59),
-//                LocalDateTime.of(2025,12,26,23,59)
-//        );
-//
-//        // when
-//        MvcResult mvcResult = mockMvc.perform(post("/api/meetings")
-//                .contentType(MediaType.APPLICATION_JSON)
-//                .content(objectMapper.writeValueAsString(request))
-//                )
-//                .andExpect(status().isBadRequest())
-//                .andDo(print())
-//                .andReturn();
-//
-//        // then
-//        verifyNoInteractions(meetingService);
-//        Integer status = mvcResult.getResponse().getStatus();
-//        assertThat(status).isEqualTo(HttpStatus.BAD_REQUEST.value());
-//    }
+        MeetingCreateRequest request = new MeetingCreateRequest(
+                "모잇 오프라인",
+                LocalDateTime.of(2025,12,30,14,0),
+                LocalDateTime.of(2025,12,15,23,59),
+                LocalDateTime.of(2025,12,26,23,59)
+        );
 
-    // Todo: admin 관련 테스트 코드 작성 후 추가 예정.
+        // when
+        MvcResult mvcResult = mockMvc.perform(post("/api/meetings")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+                )
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andReturn();
+
+        // then
+        verify(meetingService, times(1)).createMeeting(memberId, request);
+        Integer status = mvcResult.getResponse().getStatus();
+        assertThat(status).isEqualTo(HttpStatus.OK.value());
+    }
+
+    @Test
+    @DisplayName("모임 이름 Blank일 시 생성 실패")
+    void 모임_생성_실패_모임_이름_blank() throws Exception{
+        // given
+        MeetingCreateRequest request = new MeetingCreateRequest(
+                "  ",
+                LocalDateTime.of(2025,12,30,14,0),
+                LocalDateTime.of(2025,12,15,23,59),
+                LocalDateTime.of(2025,12,26,23,59)
+        );
+
+        // when
+        MvcResult mvcResult = mockMvc.perform(post("/api/meetings")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+                )
+                .andExpect(status().isBadRequest())
+                .andDo(print())
+                .andReturn();
+
+        // then
+        verifyNoInteractions(meetingService);
+        Integer status = mvcResult.getResponse().getStatus();
+        assertThat(status).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    }
+
+    @Test
+    @DisplayName("정상 요청 시 모임 삭제 성공")
     void 모임_삭제_성공() throws Exception {
+        // given
+        Long memberId = 1L;
+        AuthTestPrincipalContext.setMemberId(memberId);
 
+        Long meetingId = 1L;
+
+        // when
+        MvcResult mvcResult = mockMvc.perform(delete("/api/meetings/{id}", meetingId))
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andReturn();
+
+        // then
+        verify(meetingService, times(1)).deleteMeeting(memberId, meetingId);
+        Integer status = mvcResult.getResponse().getStatus();
+        assertThat(status).isEqualTo(HttpStatus.OK.value());
     }
 
-    void 모임_삭제_실패() throws Exception {
+    @Test
+    @DisplayName("잘못된 형식의 meetingId 넘겼을 때 모임 삭제 실패")
+    void 모임_삭제_실패_잘못된_pathVariable() throws Exception {
+        // given
+        String meetingId = "abc";
 
+        // when
+        MvcResult mvcResult = mockMvc.perform(delete("/api/meetings/{id}", meetingId))
+                .andExpect(status().isBadRequest())
+                .andDo(print())
+                .andReturn();
+
+        // then
+        verifyNoInteractions(meetingService);
+        Integer status = mvcResult.getResponse().getStatus();
+        assertThat(status).isEqualTo(HttpStatus.BAD_REQUEST.value());
     }
 
+    @Test
+    @DisplayName("정상 요청 시 모임 탈퇴 성공")
     void 모임_탈퇴_성공() throws Exception {
+        // given
+        Long memberId = 1L;
+        AuthTestPrincipalContext.setMemberId(memberId);
 
+        Long meetingId = 1L;
+
+        // when
+        MvcResult mvcResult = mockMvc.perform(delete("/api/meetings/quit/{id}", meetingId))
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andReturn();
+
+        // then
+        verify(meetingService, times(1)).quitMeeting(memberId, meetingId);
+        Integer status = mvcResult.getResponse().getStatus();
+        assertThat(status).isEqualTo(HttpStatus.OK.value());
     }
 
-    void 모임_탈퇴_실패() throws Exception {
+    @Test
+    @DisplayName("잘못된 형식의 meetingId 넘겼을 때 모임 삭제 실패")
+    void 모임_탈퇴_실패_잘못된_pathVariable() throws Exception {
+        // given
+        String meetingId = "abc";
 
+        // when
+        MvcResult mvcResult = mockMvc.perform(delete("/api/meetings/quit/{id}", meetingId))
+                .andExpect(status().isBadRequest())
+                .andDo(print())
+                .andReturn();
+
+        // then
+        verifyNoInteractions(meetingService);
+        Integer status = mvcResult.getResponse().getStatus();
+        assertThat(status).isEqualTo(HttpStatus.BAD_REQUEST.value());
     }
 
+    @Test
+    @DisplayName("정상 요청 시 모임 수정 성공")
     void 모임_수정_성공() throws Exception {
+        // given
+        Long memberId = 1L;
+        AuthTestPrincipalContext.setMemberId(memberId);
+
+        Long meetingId = 1L;
+
+        MeetingUpdateRequest request = new MeetingUpdateRequest(
+                "모잇 오프라인",
+                LocalDateTime.of(2025,12,30,14,0),
+                LocalDateTime.of(2025,12,15,23,59),
+                LocalDateTime.of(2025,12,26,23,59)
+        );
+
+        // when
+        MvcResult mvcResult = mockMvc.perform(patch("/api/meetings/{id}", meetingId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+                )
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andReturn();
+
+        // then
+        verify(meetingService, times(1)).updateMeeting(memberId, meetingId, request);
+        Integer status = mvcResult.getResponse().getStatus();
+        assertThat(status).isEqualTo(HttpStatus.OK.value());
 
     }
 
+    @Test
+    @DisplayName("잘못된 형식의 meetingId 넘겼을 때 모임 삭제 실패")
     void 모임_수정_실패() throws Exception {
+        // given
+        String meetingId = "abc";
 
+        MeetingUpdateRequest request = new MeetingUpdateRequest(
+                "모잇 오프라인",
+                LocalDateTime.of(2025,12,30,14,0),
+                LocalDateTime.of(2025,12,15,23,59),
+                LocalDateTime.of(2025,12,26,23,59)
+        );
+
+        // when
+        MvcResult mvcResult = mockMvc.perform(patch("/api/meetings/{id}", meetingId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+                )
+                .andExpect(status().isBadRequest())
+                .andDo(print())
+                .andReturn();
+
+        // then
+        verifyNoInteractions(meetingService);
+        Integer status = mvcResult.getResponse().getStatus();
+        assertThat(status).isEqualTo(HttpStatus.BAD_REQUEST.value());
     }
 }

--- a/src/test/java/pyws/swyp/meeting/service/HomeServiceTest.java
+++ b/src/test/java/pyws/swyp/meeting/service/HomeServiceTest.java
@@ -8,7 +8,7 @@ import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import pyws.swyp.meeting.dto.*;
-import pyws.swyp.meeting.entity.Role;
+import pyws.swyp.meeting.entity.ParticipantRole;
 import pyws.swyp.meeting.entity.Status;
 import pyws.swyp.meeting.repository.MeetingParticipantRepository;
 import pyws.swyp.member.entity.CharacterType;
@@ -44,11 +44,11 @@ public class HomeServiceTest {
                 new MeetingBriefResponse(2L, "카공", Status.PLACE_VOTING, fixedNow.plusDays(6))
         );
 
-        ParticipantResponse p1 = new ParticipantResponse(memberId, "닉네임1", CharacterType.FOODIE, Role.HOST);
-        ParticipantResponse p2 = new ParticipantResponse(2L, "닉네임2", CharacterType.TRAVELER, Role.MEMBER);
-        ParticipantResponse p3 = new ParticipantResponse(3L, "닉네임3", CharacterType.HEALER, Role.MEMBER);
-        ParticipantResponse p4 = new ParticipantResponse(4L, "닉네임4", CharacterType.STUDYER, Role.MEMBER);
-        ParticipantResponse p5 = new ParticipantResponse(5L, "닉네임5", CharacterType.FOODIE, Role.MEMBER);
+        ParticipantResponse p1 = new ParticipantResponse(memberId, "닉네임1", CharacterType.FOODIE, pyws.swyp.meeting.entity.ParticipantRole.HOST);
+        ParticipantResponse p2 = new ParticipantResponse(2L, "닉네임2", CharacterType.TRAVELER, pyws.swyp.meeting.entity.ParticipantRole.MEMBER);
+        ParticipantResponse p3 = new ParticipantResponse(3L, "닉네임3", CharacterType.HEALER, ParticipantRole.MEMBER);
+        ParticipantResponse p4 = new ParticipantResponse(4L, "닉네임4", CharacterType.STUDYER, pyws.swyp.meeting.entity.ParticipantRole.MEMBER);
+        ParticipantResponse p5 = new ParticipantResponse(5L, "닉네임5", CharacterType.FOODIE, pyws.swyp.meeting.entity.ParticipantRole.MEMBER);
 
         List<ParticipantRow> participantRows = List.of(
                 new ParticipantRow(1L, p1),

--- a/src/test/java/pyws/swyp/meeting/service/HomeServiceTest.java
+++ b/src/test/java/pyws/swyp/meeting/service/HomeServiceTest.java
@@ -1,0 +1,106 @@
+package pyws.swyp.meeting.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import pyws.swyp.meeting.dto.*;
+import pyws.swyp.meeting.entity.Role;
+import pyws.swyp.meeting.entity.Status;
+import pyws.swyp.meeting.repository.MeetingParticipantRepository;
+import pyws.swyp.member.entity.CharacterType;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class HomeServiceTest {
+    @Mock
+    private MeetingParticipantRepository meetingParticipantRepository;
+
+    @InjectMocks
+    private HomeService homeService;
+
+    @Test
+    @DisplayName("")
+    void 홈화면_조회_성공() {
+        // given
+        Long memberId = 1L;
+        LocalDate fixedNow = LocalDate.now(ZoneId.of("Asia/Seoul"));
+        LocalDate fixedEnd = fixedNow.plusDays(7);
+
+        List<MeetingBriefResponse> meetingInfos = List.of(
+                new MeetingBriefResponse(3L, "데이트", Status.FIXED, fixedNow.plusDays(2)),
+                new MeetingBriefResponse(1L, "모잇 오프라인 모임", Status.PLACE_VOTING, fixedNow.plusDays(4)),
+                new MeetingBriefResponse(2L, "카공", Status.PLACE_VOTING, fixedNow.plusDays(6))
+        );
+
+        ParticipantResponse p1 = new ParticipantResponse(memberId, "닉네임1", CharacterType.FOODIE, Role.HOST);
+        ParticipantResponse p2 = new ParticipantResponse(2L, "닉네임2", CharacterType.TRAVELER, Role.MEMBER);
+        ParticipantResponse p3 = new ParticipantResponse(3L, "닉네임3", CharacterType.HEALER, Role.MEMBER);
+        ParticipantResponse p4 = new ParticipantResponse(4L, "닉네임4", CharacterType.STUDYER, Role.MEMBER);
+        ParticipantResponse p5 = new ParticipantResponse(5L, "닉네임5", CharacterType.FOODIE, Role.MEMBER);
+
+        List<ParticipantRow> participantRows = List.of(
+                new ParticipantRow(1L, p1),
+                new ParticipantRow(2L, p1),
+                new ParticipantRow(3L, p1),
+                new ParticipantRow(1L, p2),
+                new ParticipantRow(1L, p3),
+                new ParticipantRow(2L, p4),
+                new ParticipantRow(3L, p5)
+        );
+
+        List<MeetingBriefResponse> waitingMeetings = List.of(
+                new MeetingBriefResponse(1L, "모잇 오프라인 모임", Status.PLACE_VOTING, fixedNow.plusDays(4)),
+                new MeetingBriefResponse(2L, "카공", Status.PLACE_VOTING, fixedNow.plusDays(6)),
+                new MeetingBriefResponse(4L, "보드게임 모임", Status.DATE_VOTING, null),
+                new MeetingBriefResponse(5L, "동아리 전체 회식", Status.CREATED, null)
+        );
+
+        when(meetingParticipantRepository.findMeetingsByMemberIdWithin7Days(memberId, fixedNow, fixedEnd))
+                .thenReturn(meetingInfos);
+
+        when(meetingParticipantRepository.findByMeetingIds(anyList()))
+                .thenReturn(participantRows);
+
+        when(meetingParticipantRepository.findMeetingsByMemberIdAndStatus(
+                eq(memberId),
+                anyList(),
+                any()
+        )).thenReturn(waitingMeetings);
+
+        // when
+        try(MockedStatic<LocalDate> mocked = mockStatic(LocalDate.class)) {
+            mocked.when(() -> LocalDate.now(ZoneId.of("Asia/Seoul"))).thenReturn(fixedNow);
+
+            HomeResponse result = homeService.getHomeInfo(memberId);
+
+            // then
+            assertThat(result.homeMeetings()).hasSize(3);
+
+            MeetingBriefWithParticipantsResponse first = result.homeMeetings().get(0);
+            assertThat(first.meetingId()).isEqualTo(3L);
+            assertThat(first.participants()).hasSize(2);
+
+            MeetingBriefWithParticipantsResponse second = result.homeMeetings().get(1);
+            assertThat(second.meetingId()).isEqualTo(1L);
+            assertThat(second.participants()).hasSize(3);
+
+            MeetingBriefWithParticipantsResponse third = result.homeMeetings().get(2);
+            assertThat(third.meetingId()).isEqualTo(2L);
+            assertThat(third.participants()).hasSize(2);
+
+            assertThat(result.waitingMeetings()).isEqualTo(waitingMeetings);
+        }
+    }
+}

--- a/src/test/java/pyws/swyp/meeting/service/MeetingServiceTest.java
+++ b/src/test/java/pyws/swyp/meeting/service/MeetingServiceTest.java
@@ -2,6 +2,7 @@ package pyws.swyp.meeting.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -28,6 +29,7 @@ import pyws.swyp.meeting.entity.MeetingParticipant;
 import pyws.swyp.meeting.entity.Role;
 import pyws.swyp.meeting.repository.MeetingParticipantRepository;
 import pyws.swyp.meeting.repository.MeetingRepository;
+import pyws.swyp.member.entity.CharacterType;
 import pyws.swyp.member.entity.Gender;
 import pyws.swyp.member.entity.Member;
 import pyws.swyp.member.repository.MemberRepository;
@@ -68,7 +70,8 @@ public class MeetingServiceTest {
                 "닉네임",
                 LocalDate.of(2000,1,1),
                 Gender.FEMALE,
-                pyws.swyp.member.entity.Role.MEMBER
+                pyws.swyp.member.entity.Role.MEMBER,
+                CharacterType.TRAVELER
                 );
         // Todo: 추후 변경된 로직에 맞게 변경 필요.
         when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));

--- a/src/test/java/pyws/swyp/meeting/service/MeetingServiceTest.java
+++ b/src/test/java/pyws/swyp/meeting/service/MeetingServiceTest.java
@@ -2,7 +2,7 @@ package pyws.swyp.meeting.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.when;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -20,13 +21,17 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import pyws.swyp.global.error.CustomException;
 import pyws.swyp.global.error.ErrorCode;
+import pyws.swyp.meeting.dto.MeetingBriefResponse;
 import pyws.swyp.meeting.dto.MeetingCreateRequest;
 import pyws.swyp.meeting.dto.MeetingUpdateRequest;
 import pyws.swyp.meeting.entity.Meeting;
 import pyws.swyp.meeting.entity.MeetingParticipant;
 import pyws.swyp.meeting.entity.Role;
+import pyws.swyp.meeting.entity.Status;
 import pyws.swyp.meeting.repository.MeetingParticipantRepository;
 import pyws.swyp.meeting.repository.MeetingRepository;
 import pyws.swyp.member.entity.CharacterType;
@@ -46,7 +51,8 @@ public class MeetingServiceTest {
     @InjectMocks
     private MeetingService meetingService;
 
-    LocalDateTime now = LocalDateTime.now();
+    LocalDate nowDate = LocalDate.now();
+    LocalDateTime nowDateTime = LocalDateTime.now();
 
     /*
     * 모임 생성
@@ -59,9 +65,9 @@ public class MeetingServiceTest {
         MeetingCreateRequest request = mock(MeetingCreateRequest.class);
         Meeting meeting = Meeting.builder()
                 .title("테스트 모임 생성")
-                .date(now.plusDays(7))
-                .dateVoteDeadline(now.plusDays(1))
-                .courseVoteDeadline(now.plusDays(3))
+                .date(nowDate.plusDays(7))
+                .dateVoteDeadline(nowDateTime.plusDays(1))
+                .courseVoteDeadline(nowDateTime.plusDays(3))
                 .build();
         when(request.toMeetingEntity()).thenReturn(meeting);
 
@@ -319,7 +325,7 @@ public class MeetingServiceTest {
 
         MeetingUpdateRequest request = new MeetingUpdateRequest(
                 null,
-                LocalDateTime.of(2026,1,20,13,00),
+                LocalDate.of(2026,1,20),
                 null,
                 null
         );
@@ -359,7 +365,7 @@ public class MeetingServiceTest {
 
         MeetingUpdateRequest request = new MeetingUpdateRequest(
                 null,
-                LocalDateTime.of(2026,1,20,13,00),
+                LocalDate.of(2026,1,20),
                 null,
                 null
         );
@@ -401,7 +407,7 @@ public class MeetingServiceTest {
 
         MeetingUpdateRequest request = new MeetingUpdateRequest(
                 " ",
-                LocalDateTime.of(2026,1,20,13,00),
+                LocalDate.of(2026,1,20),
                 null,
                 null
         );
@@ -428,6 +434,59 @@ public class MeetingServiceTest {
         assertThat(meeting.getDateVoteDeadline()).isEqualTo(LocalDateTime.of(2025,12,31,13,00));
         assertThat(meeting.getCourseVoteDeadline()).isNull();
 
+    }
+
+    /*
+    * 모임 조회
+    */
+
+    @Test
+    @DisplayName("모임 전체 조회 성공")
+    void 모임_전체_조회_성공() {
+        // given
+        Long memberId = 1L;
+
+        List<MeetingBriefResponse> response = List.of(mock(MeetingBriefResponse.class));
+        when(meetingParticipantRepository.findMeetingsByMemberId(memberId)).thenReturn(response);
+
+        // when
+        List<MeetingBriefResponse> result = meetingService.getAllMeetings(memberId);
+
+        // then
+        assertThat(result).isEqualTo(response);
+        verify(meetingParticipantRepository, times(1)).findMeetingsByMemberId(memberId);
+    }
+
+    @Test
+    @DisplayName("대기 중 모임 조회 성공 - CREATED, DATE_VOTING, PLACE_VOTING 상태만 조회")
+    void 대기중_모임_조회_성공() {
+        // given
+        Long memberId = 1L;
+        Pageable pageable = PageRequest.of(0,10);
+
+        List<MeetingBriefResponse> response = List.of(mock(MeetingBriefResponse.class));
+
+        when(meetingParticipantRepository.findMeetingsByMemberIdAndStatus(
+                eq(memberId),
+                anyList(),
+                eq(pageable)
+        )).thenReturn(response);
+
+        // when
+        List<MeetingBriefResponse> result = meetingService.getWaitingMeetings(memberId, pageable);
+
+        // then
+        assertThat(result).isEqualTo(response);
+        verify(meetingParticipantRepository, times(1))
+                .findMeetingsByMemberIdAndStatus(
+                        eq(memberId),
+                        eq(List.of(
+                                Status.CREATED,
+                                Status.DATE_VOTING,
+                                Status.PLACE_VOTING
+                        )),
+                        eq(pageable)
+                );
     }
 
 }

--- a/src/test/java/pyws/swyp/meeting/service/MeetingServiceTest.java
+++ b/src/test/java/pyws/swyp/meeting/service/MeetingServiceTest.java
@@ -344,7 +344,7 @@ public class MeetingServiceTest {
         verify(meetingParticipantRepository).findByMemberIdAndMeetingId(memberId, meetingId);
 
         assertThat(meeting.getTitle()).isEqualTo("모잇 오프라인 모임");
-        assertThat(meeting.getDate()).isEqualTo(LocalDateTime.of(2026,1,20,13,00));
+        assertThat(meeting.getDate()).isEqualTo(LocalDate.of(2026,1,20));
         assertThat(meeting.getDateVoteDeadline()).isEqualTo(LocalDateTime.of(2025,12,31,13,00));
         assertThat(meeting.getCourseVoteDeadline()).isNull();
     }

--- a/src/test/java/pyws/swyp/meeting/service/MeetingServiceTest.java
+++ b/src/test/java/pyws/swyp/meeting/service/MeetingServiceTest.java
@@ -30,13 +30,14 @@ import pyws.swyp.meeting.dto.MeetingCreateRequest;
 import pyws.swyp.meeting.dto.MeetingUpdateRequest;
 import pyws.swyp.meeting.entity.Meeting;
 import pyws.swyp.meeting.entity.MeetingParticipant;
-import pyws.swyp.meeting.entity.Role;
+import pyws.swyp.meeting.entity.ParticipantRole;
 import pyws.swyp.meeting.entity.Status;
 import pyws.swyp.meeting.repository.MeetingParticipantRepository;
 import pyws.swyp.meeting.repository.MeetingRepository;
 import pyws.swyp.member.entity.CharacterType;
 import pyws.swyp.member.entity.Gender;
 import pyws.swyp.member.entity.Member;
+import pyws.swyp.member.entity.MemberRole;
 import pyws.swyp.member.repository.MemberRepository;
 
 @ExtendWith(MockitoExtension.class)
@@ -76,7 +77,7 @@ public class MeetingServiceTest {
                 "닉네임",
                 LocalDate.of(2000,1,1),
                 Gender.FEMALE,
-                pyws.swyp.member.entity.Role.MEMBER,
+                MemberRole.MEMBER,
                 CharacterType.TRAVELER
                 );
         // Todo: 추후 변경된 로직에 맞게 변경 필요.
@@ -93,7 +94,7 @@ public class MeetingServiceTest {
         MeetingParticipant savedParticipant = captor.getValue();
         assertThat(savedParticipant.getMeeting()).isSameAs(meeting);
         assertThat(savedParticipant.getMember()).isSameAs(member);
-        assertThat(savedParticipant.getRole()).isEqualTo(Role.HOST);
+        assertThat(savedParticipant.getParticipantRole()).isEqualTo(pyws.swyp.meeting.entity.ParticipantRole.HOST);
     }
 
     @Test
@@ -132,7 +133,7 @@ public class MeetingServiceTest {
         when(meetingRepository.findById(meetingId)).thenReturn(Optional.of(meeting));
 
         MeetingParticipant meetingParticipant = mock(MeetingParticipant.class);
-        when(meetingParticipant.getRole()).thenReturn(Role.HOST);
+        when(meetingParticipant.getParticipantRole()).thenReturn(ParticipantRole.HOST);
         when(meetingParticipantRepository.findByMemberIdAndMeetingId(memberId, meetingId))
                 .thenReturn(Optional.of(meetingParticipant));
 
@@ -203,7 +204,7 @@ public class MeetingServiceTest {
         when(meetingRepository.findById(meetingId)).thenReturn(Optional.of(meeting));
 
         MeetingParticipant meetingParticipant = mock(MeetingParticipant.class);
-        when(meetingParticipant.getRole()).thenReturn(Role.MEMBER);
+        when(meetingParticipant.getParticipantRole()).thenReturn(pyws.swyp.meeting.entity.ParticipantRole.MEMBER);
         when(meetingParticipantRepository.findByMemberIdAndMeetingId(memberId, meetingId))
                 .thenReturn(Optional.of(meetingParticipant));
 
@@ -236,7 +237,7 @@ public class MeetingServiceTest {
         when(meetingRepository.findById(meetingId)).thenReturn(Optional.of(meeting));
 
         MeetingParticipant meetingParticipant = mock(MeetingParticipant.class);
-        when(meetingParticipant.getRole()).thenReturn(Role.MEMBER);
+        when(meetingParticipant.getParticipantRole()).thenReturn(pyws.swyp.meeting.entity.ParticipantRole.MEMBER);
         when(meetingParticipantRepository.findByMemberIdAndMeetingId(memberId, meetingId))
                 .thenReturn(Optional.of(meetingParticipant));
 
@@ -288,7 +289,7 @@ public class MeetingServiceTest {
         when(meetingRepository.findById(meetingId)).thenReturn(Optional.of(meeting));
 
         MeetingParticipant meetingParticipant = mock(MeetingParticipant.class);
-        when(meetingParticipant.getRole()).thenReturn(Role.HOST);
+        when(meetingParticipant.getParticipantRole()).thenReturn(pyws.swyp.meeting.entity.ParticipantRole.HOST);
         when(meetingParticipantRepository.findByMemberIdAndMeetingId(memberId, meetingId))
                 .thenReturn(Optional.of(meetingParticipant));
 

--- a/src/test/java/pyws/swyp/member/controller/MemberControllerTest.java
+++ b/src/test/java/pyws/swyp/member/controller/MemberControllerTest.java
@@ -28,13 +28,8 @@ import pyws.swyp.config.TestRedisConfig;
 import pyws.swyp.global.error.ErrorCode;
 import pyws.swyp.member.dto.MemberWithdrawRequest;
 import pyws.swyp.member.dto.SocialLinkRequest;
-import pyws.swyp.member.entity.CharacterType;
-import pyws.swyp.member.entity.Gender;
-import pyws.swyp.member.entity.Member;
-import pyws.swyp.member.entity.Role;
-import pyws.swyp.member.entity.SocialAccount;
-import pyws.swyp.member.entity.SocialProvider;
-import pyws.swyp.member.entity.WithdrawalType;
+import pyws.swyp.member.entity.*;
+import pyws.swyp.member.entity.MemberRole;
 import pyws.swyp.member.repository.MemberRepository;
 import pyws.swyp.member.repository.MemberWithdrawalRepository;
 import pyws.swyp.member.repository.SocialAccountRepository;
@@ -73,7 +68,7 @@ class MemberControllerTest {
                 .nickname("테스트")
                 .gender(Gender.MALE)
                 .birthDate(of(1999, 1, 1))
-                .role(Role.MEMBER)
+                .memberRole(MemberRole.MEMBER)
                 .characterType(CharacterType.ACTIVE)
                 .build());
 
@@ -99,7 +94,7 @@ class MemberControllerTest {
                 .andExpect(jsonPath("$.data.email").value("test@example.com"))
                 .andExpect(jsonPath("$.data.nickname").value("테스트"))
                 .andExpect(jsonPath("$.data.gender").value("MALE"))
-                .andExpect(jsonPath("$.data.role").value("MEMBER"))
+                .andExpect(jsonPath("$.data.memberRole").value("MEMBER"))
                 .andExpect(jsonPath("$.data.socialAccounts[0].socialProvider").value(this.provider.name()));
     }
 

--- a/src/test/java/pyws/swyp/member/service/MemberServiceTest.java
+++ b/src/test/java/pyws/swyp/member/service/MemberServiceTest.java
@@ -25,7 +25,7 @@ import pyws.swyp.member.entity.CharacterType;
 import pyws.swyp.member.entity.Gender;
 import pyws.swyp.member.entity.Member;
 import pyws.swyp.member.entity.MemberWithdrawal;
-import pyws.swyp.member.entity.Role;
+import pyws.swyp.member.entity.MemberRole;
 import pyws.swyp.member.entity.SocialAccount;
 import pyws.swyp.member.entity.SocialProvider;
 import pyws.swyp.member.entity.WithdrawalType;
@@ -65,7 +65,7 @@ class MemberServiceTest {
                 .nickname("테스트")
                 .birthDate(LocalDate.of(1999, 1, 1))
                 .gender(Gender.MALE)
-                .role(Role.MEMBER)
+                .memberRole(MemberRole.MEMBER)
                 .characterType(CharacterType.ACTIVE)
                 .build());
 
@@ -97,7 +97,7 @@ class MemberServiceTest {
         assertEquals("테스트", response.nickname());
         assertEquals(LocalDate.of(1999, 1, 1), response.birthDate());
         assertEquals(Gender.MALE, response.gender());
-        assertEquals(Role.MEMBER, response.role());
+        assertEquals(MemberRole.MEMBER, response.memberRole());
 
         List<SocialProvider> providers = response.socialAccounts().stream()
                 .map(SocialAccountInfo::socialProvider)

--- a/src/test/java/pyws/swyp/member/service/SocialAccountServiceTest.java
+++ b/src/test/java/pyws/swyp/member/service/SocialAccountServiceTest.java
@@ -17,7 +17,7 @@ import pyws.swyp.member.dto.SocialLinkRequest;
 import pyws.swyp.member.entity.CharacterType;
 import pyws.swyp.member.entity.Gender;
 import pyws.swyp.member.entity.Member;
-import pyws.swyp.member.entity.Role;
+import pyws.swyp.member.entity.MemberRole;
 import pyws.swyp.member.entity.SocialAccount;
 import pyws.swyp.member.entity.SocialProvider;
 import pyws.swyp.member.repository.MemberRepository;
@@ -50,7 +50,7 @@ class SocialAccountServiceTest {
                 .nickname("테스트")
                 .birthDate(LocalDate.of(1999, 1, 1))
                 .gender(Gender.MALE)
-                .role(Role.MEMBER)
+                .memberRole(MemberRole.MEMBER)
                 .characterType(CharacterType.ACTIVE)
                 .build());
     }


### PR DESCRIPTION
### 📌 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- 기능 추가

### 📌 관련 이슈
#20 

### ✨ 반영 브랜치
feat/20 -> develop

### 📝 변경 사항
- [X] Meeting 내 LocalDateTime 형식이었던 date -> LocalDate date, LocalTime time으로 분리하여 변경

- [X] 전체 모임 리스트 조회
  - [X] 캘린더뷰에 사용
- [X] 대기 중인 모임 리스트 조회
  - [X] 홈화면 -> 친구들이 기다려요 [더보기]로 이어질 때 사용되는 조회 
- [X] 홈화면 조회
  - [X] 7일 이내 예정된 모임 리스트 조회
    - [X] 날짜가 확정된 것 기준으로 조회
    - [X] 날짜 오름차순으로 정렬
    - [X] 이 경우 UI 내 캐릭터가 있어서 모임 참여자들의 메타데이터 또한 함께 반환
  - [X] 대기중인 모임 리스트 조회
    - [X] 최대 3개만 조회
    - [X] meeting.status가 created, date_voting, place_voting 인 것만 조회

### ➕ 추가 메모
- 홈화면 조회 시 우선 최상단 멘트 및 유저 정보(캐릭터)는 포함하지 않음. 추후 프론트에서 요청 시 추가 예정
- 모임 상세보기 구현하지 않음.
   - 모임 구성원은 조회는 초대 관련 PR에 함께 할 예정이며, 날짜 및 시간 확정은 투표에서 조회를 담당할지 모임에서 담당할지 정해진 후에 추가 예정

### 🐛 테스트 결과 (테스트 결과가 있다면 넣어주세요)
<img width="1146" height="872" alt="image" src="https://github.com/user-attachments/assets/98c8ec2f-0fb7-4091-adca-aa24be710b9d" />

