### PR TITLE
feat: #27 모임장 날짜/시간 투표 확정/취소 기능 추가

### DIFF
--- a/src/main/java/pyws/swyp/global/error/ErrorCode.java
+++ b/src/main/java/pyws/swyp/global/error/ErrorCode.java
@@ -36,6 +36,8 @@ public enum ErrorCode {
     MEETING_TITLE_EMPTY(BAD_REQUEST, "MEET0004", "모임 제목은 필수이며, 빈칸일 수 없습니다."),
     MEETING_NOT_VOTABLE(BAD_REQUEST, "MEET0005", "이미 확정됐거나 완료된 모임입니다."),
     MEETING_PARTICIPANT_NOT_FOUND(NOT_FOUND, "MEET0006", "존재하지 않는 모임원입니다."),
+    MEETING_HOST_ONLY(HttpStatus.FORBIDDEN, "MEET0007", "모임장만 투표 확정 및 취소를 할 수 있습니다."),
+    MEETING_NOT_CONFIRMABLE(HttpStatus.BAD_REQUEST, "MEET0008", "현재 모임 상태에서는 투표 확정 또는 취소를 할 수 없습니다."),
 
     // Vote
     DATE_VOTE_NOT_FOUND(NOT_FOUND, "VOTE0001", "아직 시간 투표가 존재하지 않습니다."),

--- a/src/main/java/pyws/swyp/meeting/controller/MeetingConfirmController.java
+++ b/src/main/java/pyws/swyp/meeting/controller/MeetingConfirmController.java
@@ -1,0 +1,72 @@
+package pyws.swyp.meeting.controller;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import pyws.swyp.meeting.controller.api.MeetingConfirmApi;
+import pyws.swyp.meeting.service.MeetingConfirmService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/meetings/{meetingId}/votes")
+public class MeetingConfirmController implements MeetingConfirmApi {
+
+    private final MeetingConfirmService meetingConfirmService;
+
+    @PostMapping("/date/confirm")
+    public void confirmDateVote(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long meetingId
+    ) {
+        meetingConfirmService.confirmDateVote(memberId, meetingId);
+    }
+
+    @PostMapping("/date/confirm/manual")
+    public void confirmDateManual(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long meetingId,
+            @RequestParam LocalDate date
+            ) {
+        meetingConfirmService.confirmDate(memberId, meetingId, date);
+    }
+
+    @DeleteMapping("/date/confirm")
+    public void cancelConfirmDate(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long meetingId
+    ) {
+        meetingConfirmService.cancelConfirmDateVote(memberId, meetingId);
+    }
+
+    @PostMapping("/time/confirm")
+    public void confirmTimeVote(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long meetingId
+    ) {
+        meetingConfirmService.confirmTimeVote(memberId, meetingId);
+    }
+
+    @PostMapping("/time/confirm/manual")
+    public void confirmTimeManual(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long meetingId,
+            @RequestParam LocalTime time
+    ) {
+        meetingConfirmService.confirmTime(memberId, meetingId, time);
+    }
+
+    @DeleteMapping("/time/confirm")
+    public void cancelConfirmTime(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long meetingId
+    ) {
+        meetingConfirmService.cancelConfirmTimeVote(memberId, meetingId);
+    }
+}

--- a/src/main/java/pyws/swyp/meeting/controller/api/MeetingConfirmApi.java
+++ b/src/main/java/pyws/swyp/meeting/controller/api/MeetingConfirmApi.java
@@ -1,0 +1,144 @@
+package pyws.swyp.meeting.controller.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@SecurityRequirement(name = "auth")
+@Tag(name = "Meeting Confirm API", description = "모임 날짜/시간 확정 및 확정 취소 API")
+public interface MeetingConfirmApi {
+
+    @Operation(
+            summary = "날짜 투표 결과로 확정",
+            description = """
+                    모임의 날짜 투표 결과를 기반으로 날짜를 확정합니다.
+                    
+                    - 최다 득표한 날짜 후보들 중 가장 과거 날짜로 확정됩니다.
+                    - Authorization 헤더에 Access Token이 필요합니다.
+                    """
+    )
+    @ApiResponse(responseCode = "200", description = "날짜 확정 성공")
+    void confirmDateVote(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal Long memberId,
+
+            @Parameter(description = "모임 ID", example = "1")
+            @PathVariable Long meetingId
+    );
+
+    @Operation(
+            summary = "날짜 수동 확정",
+            description = """
+                    모임장이 특정 날짜를 직접 지정하여 모임 날짜를 확정합니다.
+                    
+                    - 날짜 형식: yyyy-MM-dd
+                    - Authorization 헤더에 Access Token이 필요합니다.
+                    """
+    )
+    @ApiResponse(responseCode = "200", description = "날짜 수동 확정 성공")
+    @ApiResponse(
+            responseCode = "400",
+            description = "잘못된 요청 (날짜 형식 오류 등)",
+            content = @Content(examples = @ExampleObject(value = """
+                    {"code":"COM0001","message":"잘못된 요청입니다.","data":{"date":"값의 형식이 올바르지 않습니다. (입력값: 2025-13-40)"}}
+                    """))
+    )
+    void confirmDateManual(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal Long memberId,
+
+            @Parameter(description = "모임 ID", example = "1")
+            @PathVariable Long meetingId,
+
+            @Parameter(description = "확정할 날짜", example = "2025-12-20")
+            @RequestParam LocalDate date
+    );
+
+    @Operation(
+            summary = "확정된 날짜 취소",
+            description = """
+                    확정된 모임 날짜를 취소합니다.
+                    
+                    - Authorization 헤더에 Access Token이 필요합니다.
+                    """
+    )
+    @ApiResponse(responseCode = "200", description = "날짜 확정 취소 성공")
+    void cancelConfirmDate(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal Long memberId,
+
+            @Parameter(description = "모임 ID", example = "1")
+            @PathVariable Long meetingId
+    );
+
+    @Operation(
+            summary = "시간 투표 결과로 확정",
+            description = """
+                    모임의 시간 투표 결과를 기반으로 시간을 확정합니다.
+                    
+                    - Authorization 헤더에 Access Token이 필요합니다.
+                    """
+    )
+    @ApiResponse(responseCode = "200", description = "시간 확정 성공")
+    void confirmTimeVote(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal Long memberId,
+
+            @Parameter(description = "모임 ID", example = "1")
+            @PathVariable Long meetingId
+    );
+
+    @Operation(
+            summary = "시간 수동 확정",
+            description = """
+                    호스트가 특정 시간을 직접 지정하여 모임 시간을 확정합니다.
+                    
+                    - 시간 형식: HH:mm
+                    - Authorization 헤더에 Access Token이 필요합니다.
+                    """
+    )
+    @ApiResponse(responseCode = "200", description = "시간 수동 확정 성공")
+    @ApiResponse(
+            responseCode = "400",
+            description = "잘못된 요청 (시간 형식 오류 등)",
+            content = @Content(examples = @ExampleObject(value = """
+                    {"code":"COM0001","message":"잘못된 요청입니다.","data":{"time":"값의 형식이 올바르지 않습니다. (입력값: 99:99)"}}
+                    """))
+    )
+    void confirmTimeManual(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal Long memberId,
+
+            @Parameter(description = "모임 ID", example = "1")
+            @PathVariable Long meetingId,
+
+            @Parameter(description = "확정할 시간", example = "15:00")
+            @RequestParam LocalTime time
+    );
+
+    @Operation(
+            summary = "확정된 시간 취소",
+            description = """
+                    확정된 모임 시간을 취소합니다.
+                    
+                    - Authorization 헤더에 Access Token이 필요합니다.
+                    """
+    )
+    @ApiResponse(responseCode = "200", description = "시간 확정 취소 성공")
+    void cancelConfirmTime(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal Long memberId,
+
+            @Parameter(description = "모임 ID", example = "1")
+            @PathVariable Long meetingId
+    );
+}

--- a/src/main/java/pyws/swyp/meeting/entity/Meeting.java
+++ b/src/main/java/pyws/swyp/meeting/entity/Meeting.java
@@ -76,4 +76,24 @@ public class Meeting extends BaseEntity {
             this.courseVoteDeadline = request.courseVoteDeadline();
         }
     }
+
+    public void confirmDate(LocalDate date) {
+        this.date = date;
+        updateStatus(MeetingStatus.DATE_VOTED);
+    }
+
+    public void cancelConfirmedDate() {
+        this.date = null;
+        updateStatus(MeetingStatus.DATE_VOTING);
+    }
+
+    public void confirmTime(LocalTime time) {
+        this.time = time;
+        updateStatus(MeetingStatus.TIME_VOTED);
+    }
+
+    public void cancelConfirmedTime() {
+        this.time = null;
+        updateStatus(MeetingStatus.TIME_VOTING);
+    }
 }

--- a/src/main/java/pyws/swyp/meeting/entity/MeetingParticipant.java
+++ b/src/main/java/pyws/swyp/meeting/entity/MeetingParticipant.java
@@ -45,4 +45,8 @@ public class MeetingParticipant extends BaseEntity {
                 .role(ParticipantRole.HOST)
                 .build();
     }
+
+    public boolean isHost() {
+        return ParticipantRole.HOST.equals(this.role);
+    }
 }

--- a/src/main/java/pyws/swyp/meeting/entity/MeetingStatus.java
+++ b/src/main/java/pyws/swyp/meeting/entity/MeetingStatus.java
@@ -9,14 +9,32 @@ public enum MeetingStatus {
 
     CREATED(1),
     DATE_VOTING(2),
-    PLACE_VOTING(3),
-    FIXED(4),
-    DONE(5),
-    ;
-
+    DATE_VOTED(3),
+    TIME_VOTING(4),
+    TIME_VOTED(5),
+    PLACE_VOTING(6),
+    PLACE_VOTED(7),
+    FIXED(8),
+    DONE(9);
     private final int level;
 
     public boolean isNotVotable() {
         return this == FIXED || this == DONE;
+    }
+
+    public boolean isDateVotable() {
+        return this == CREATED || this == DATE_VOTING;
+    }
+
+    public boolean isTimeVotable() {
+        return this == DATE_VOTED || this == TIME_VOTING;
+    }
+
+    public boolean isDateVoteVisible() {
+        return this.level >= DATE_VOTING.level;
+    }
+
+    public boolean isTimeVoteVisible() {
+        return this.level >= TIME_VOTING.level;
     }
 }

--- a/src/main/java/pyws/swyp/meeting/service/MeetingConfirmService.java
+++ b/src/main/java/pyws/swyp/meeting/service/MeetingConfirmService.java
@@ -1,0 +1,174 @@
+package pyws.swyp.meeting.service;
+
+import static pyws.swyp.global.error.ErrorCode.DATE_VOTE_NOT_FOUND;
+import static pyws.swyp.global.error.ErrorCode.MEETING_HOST_ONLY;
+import static pyws.swyp.global.error.ErrorCode.MEETING_NOT_CONFIRMABLE;
+import static pyws.swyp.global.error.ErrorCode.MEETING_NOT_FOUND;
+import static pyws.swyp.global.error.ErrorCode.MEETING_PARTICIPANT_NOT_FOUND;
+import static pyws.swyp.global.error.ErrorCode.TIME_VOTE_NOT_FOUND;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import pyws.swyp.global.error.ErrorCode;
+import pyws.swyp.meeting.entity.Meeting;
+import pyws.swyp.meeting.entity.MeetingParticipant;
+import pyws.swyp.meeting.entity.MeetingStatus;
+import pyws.swyp.meeting.repository.MeetingParticipantRepository;
+import pyws.swyp.meeting.repository.MeetingRepository;
+import pyws.swyp.meeting.repository.vote.DateVoteRepository;
+import pyws.swyp.meeting.repository.vote.TimeVoteRepository;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MeetingConfirmService {
+
+    private final MeetingRepository meetingRepository;
+    private final MeetingParticipantRepository meetingParticipantRepository;
+    private final DateVoteRepository dateVoteRepository;
+    private final TimeVoteRepository timeVoteRepository;
+
+    /**
+     * 모임장이 날짜 투표 결과를 기준으로 모임 날짜를 확정한다.
+     */
+    public void confirmDateVote(Long memberId, Long meetingId) {
+        Meeting meeting = getMeeting(meetingId);
+        MeetingParticipant participant = getParticipant(memberId, meetingId);
+
+        validateHost(participant);
+
+        if (meeting.getStatus() != MeetingStatus.DATE_VOTING) {
+            throw MEETING_NOT_CONFIRMABLE.toException();
+        }
+
+        List<LocalDate> topDates = dateVoteRepository.findTopDatesByMeetingId(meetingId,
+                PageRequest.of(0, 1));
+        if (topDates.isEmpty()) {
+            throw DATE_VOTE_NOT_FOUND.toException();
+        }
+
+        LocalDate topDate = topDates.getFirst();
+
+        meeting.confirmDate(topDate);
+    }
+
+    /**
+     * 모임장이 지정한 날짜로 모임 날짜를 임의 확정한다.
+     */
+    public void confirmDate(Long memberId, Long meetingId, LocalDate date) {
+        Meeting meeting = getMeeting(meetingId);
+        MeetingParticipant participant = getParticipant(memberId, meetingId);
+
+        validateHost(participant);
+
+        if (meeting.getStatus() != MeetingStatus.DATE_VOTING) {
+            throw MEETING_NOT_CONFIRMABLE.toException();
+        }
+
+        meeting.confirmDate(date);
+    }
+
+    /**
+     * 날짜 확정을 취소하고, 모임을 DATE_VOTING 상태로 되돌린다.
+     */
+    public void cancelConfirmDateVote(Long memberId, Long meetingId) {
+        Meeting meeting = getMeeting(meetingId);
+        MeetingParticipant participant = getParticipant(memberId, meetingId);
+
+        validateHost(participant);
+
+        if (meeting.getStatus() != MeetingStatus.DATE_VOTED) {
+            throw MEETING_NOT_CONFIRMABLE.toException();
+        }
+
+        meeting.cancelConfirmedDate();
+    }
+
+    /**
+     * 모임장이 시간 투표 결과를 기준으로 모임 시간을 확정한다.
+     */
+    public void confirmTimeVote(Long memberId, Long meetingId) {
+        Meeting meeting = getMeeting(meetingId);
+        MeetingParticipant participant = getParticipant(memberId, meetingId);
+
+        validateHost(participant);
+
+        if (meeting.getStatus() != MeetingStatus.TIME_VOTING) {
+            throw MEETING_NOT_CONFIRMABLE.toException();
+        }
+
+        List<LocalTime> topTimes = timeVoteRepository.findTopTimesByMeetingId(meetingId, PageRequest.of(0, 1));
+        if (topTimes.isEmpty()) {
+            throw TIME_VOTE_NOT_FOUND.toException();
+        }
+
+        meeting.confirmTime(topTimes.getFirst());
+    }
+
+    /**
+     * 모임장이 지정한 시간으로 모임 시간을 임의 확정한다.
+     */
+    public void confirmTime(Long memberId, Long meetingId, LocalTime time) {
+        Meeting meeting = getMeeting(meetingId);
+        MeetingParticipant participant = getParticipant(memberId, meetingId);
+
+        validateHost(participant);
+
+        if (meeting.getStatus() != MeetingStatus.TIME_VOTING) {
+            throw MEETING_NOT_CONFIRMABLE.toException();
+        }
+
+        validateTimeUnit(time);
+
+        meeting.confirmTime(time);
+    }
+
+    /**
+     * 시간 확정을 취소하고, 모임을 TIME_VOTING 상태로 되돌린다.
+     */
+    public void cancelConfirmTimeVote(Long memberId, Long meetingId) {
+        Meeting meeting = getMeeting(meetingId);
+        MeetingParticipant participant = getParticipant(memberId, meetingId);
+
+        validateHost(participant);
+
+        if (meeting.getStatus() != MeetingStatus.TIME_VOTED) {
+            throw MEETING_NOT_CONFIRMABLE.toException();
+        }
+
+        meeting.cancelConfirmedTime();
+    }
+
+    private Meeting getMeeting(Long meetingId) {
+        return meetingRepository.findById(meetingId)
+                .orElseThrow(MEETING_NOT_FOUND::toException);
+    }
+
+    private MeetingParticipant getParticipant(Long memberId, Long meetingId) {
+        return meetingParticipantRepository.findByMemberIdAndMeetingId(memberId, meetingId)
+                .orElseThrow(MEETING_PARTICIPANT_NOT_FOUND::toException);
+    }
+
+    private void validateHost(MeetingParticipant participant) {
+        if (!participant.isHost()) {
+            throw MEETING_HOST_ONLY.toException();
+        }
+    }
+
+    private LocalTime validateTimeUnit(LocalTime time) {
+        int minute = time.getMinute();
+        if (minute != 0 && minute != 30) {
+            throw ErrorCode.TIME_NOT_IN_30_MIN_UNIT.toException();
+        }
+
+        if (time.getSecond() != 0 || time.getNano() != 0) {
+            throw ErrorCode.INVALID_TIME_VOTE_REQUEST.toException();
+        }
+        return time;
+    }
+}

--- a/src/test/java/pyws/swyp/meeting/controller/MeetingConfirmControllerTest.java
+++ b/src/test/java/pyws/swyp/meeting/controller/MeetingConfirmControllerTest.java
@@ -1,0 +1,180 @@
+package pyws.swyp.meeting.controller;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+import pyws.swyp.config.AuthPrincipalTestConfig;
+import pyws.swyp.config.AuthTestPrincipalContext;
+import pyws.swyp.config.TestRedisConfig;
+import pyws.swyp.global.error.ErrorCode;
+import pyws.swyp.meeting.entity.Meeting;
+import pyws.swyp.meeting.entity.MeetingParticipant;
+import pyws.swyp.meeting.entity.MeetingStatus;
+import pyws.swyp.meeting.entity.ParticipantRole;
+import pyws.swyp.meeting.repository.MeetingParticipantRepository;
+import pyws.swyp.meeting.repository.MeetingRepository;
+import pyws.swyp.meeting.repository.vote.DateVoteRepository;
+import pyws.swyp.meeting.repository.vote.TimeVoteRepository;
+import pyws.swyp.member.entity.CharacterType;
+import pyws.swyp.member.entity.Gender;
+import pyws.swyp.member.entity.Member;
+import pyws.swyp.member.entity.MemberRole;
+import pyws.swyp.member.repository.MemberRepository;
+
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)
+@Import({AuthPrincipalTestConfig.class, TestRedisConfig.class})
+class MeetingConfirmControllerTest {
+
+    ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+
+    @Autowired
+    MockMvc mockMvc;
+    @Autowired
+    MemberRepository memberRepository;
+    @Autowired
+    MeetingRepository meetingRepository;
+    @Autowired
+    MeetingParticipantRepository meetingParticipantRepository;
+    @Autowired
+    DateVoteRepository dateVoteRepository;
+    @Autowired
+    TimeVoteRepository timeVoteRepository;
+
+    private Long meetingId;
+    private Long memberId;
+
+    @BeforeEach
+    void setUp() {
+        dateVoteRepository.deleteAll();
+        timeVoteRepository.deleteAll();
+        meetingParticipantRepository.deleteAll();
+        meetingRepository.deleteAll();
+        memberRepository.deleteAll();
+
+        Member member = memberRepository.save(Member.builder()
+                .email("host@test.com")
+                .nickname("host")
+                .gender(Gender.MALE)
+                .birthDate(LocalDate.of(1999, 1, 1))
+                .role(MemberRole.MEMBER)
+                .characterType(CharacterType.ACTIVE)
+                .build());
+        this.memberId = member.getId();
+
+        Meeting meeting = meetingRepository.save(Meeting.builder()
+                .title("확정 테스트 모임")
+                .build());
+        this.meetingId = meeting.getId();
+
+        meetingParticipantRepository.save(MeetingParticipant.builder()
+                .meeting(meeting)
+                .member(member)
+                .role(ParticipantRole.HOST)
+                .build());
+
+        AuthTestPrincipalContext.setMemberId(this.memberId);
+    }
+
+    @Test
+    @DisplayName("모임장이 지정한 날짜로 투표를 확정한다.")
+    void confirmDateManual_success() throws Exception {
+        // given
+        Meeting meeting = meetingRepository.findById(meetingId).orElseThrow();
+        meeting.updateStatus(MeetingStatus.DATE_VOTING);
+        meetingRepository.save(meeting);
+
+        LocalDate chosen = LocalDate.of(2025, 12, 20);
+
+        // when
+        mockMvc.perform(post("/api/meetings/{meetingId}/votes/date/confirm/manual", meetingId)
+                        .param("date", chosen.toString()))
+                .andExpect(status().isOk())
+                .andDo(print());
+
+        // then
+        Meeting updated = meetingRepository.findById(meetingId).orElseThrow();
+        assertEquals(MeetingStatus.DATE_VOTED, updated.getStatus());
+        assertEquals(chosen, updated.getDate());
+    }
+
+    @Test
+    @DisplayName("모임장이 지정한 시간으로 투표를 확정한다.")
+    void confirmTimeManual_success() throws Exception {
+        // given
+        Meeting meeting = meetingRepository.findById(meetingId).orElseThrow();
+        meeting.updateStatus(MeetingStatus.TIME_VOTING);
+        meetingRepository.save(meeting);
+
+        LocalTime chosen = LocalTime.of(15, 0);
+
+        // when
+        mockMvc.perform(post("/api/meetings/{meetingId}/votes/time/confirm/manual", meetingId)
+                        .param("time", chosen.toString()))
+                .andExpect(status().isOk())
+                .andDo(print());
+
+        // then
+        Meeting updated = meetingRepository.findById(meetingId).orElseThrow();
+        assertEquals(MeetingStatus.TIME_VOTED, updated.getStatus());
+        assertEquals(chosen, updated.getTime());
+    }
+
+    @Test
+    @DisplayName("날짜 확정을 취소한다.")
+    void cancelConfirmDate_success() throws Exception {
+        // given
+        Meeting meeting = meetingRepository.findById(meetingId).orElseThrow();
+        meeting.updateStatus(MeetingStatus.DATE_VOTING);
+        meetingRepository.save(meeting);
+
+        LocalDate date = LocalDate.of(2025, 12, 20);
+        mockMvc.perform(post("/api/meetings/{meetingId}/votes/date/confirm/manual", meetingId)
+                        .param("date", date.toString()))
+                .andExpect(status().isOk());
+
+        // when
+        mockMvc.perform(delete("/api/meetings/{meetingId}/votes/date/confirm", meetingId))
+                .andExpect(status().isOk())
+                .andDo(print());
+
+        // then
+        Meeting updated = meetingRepository.findById(meetingId).orElseThrow();
+        assertEquals(MeetingStatus.DATE_VOTING, updated.getStatus());
+        assertNull(updated.getDate());
+    }
+
+    @Test
+    @DisplayName("시간 형식이 올바르지 않으면 400과 필드 에러를 반환한다.")
+    void confirmTimeManual_invalidTimeFormat_400() throws Exception {
+        // given
+        String invalidTime = "99:99";
+
+        // expected
+        mockMvc.perform(post("/api/meetings/{meetingId}/votes/time/confirm/manual", meetingId)
+                        .param("time", invalidTime))
+                .andExpect(status().isBadRequest())
+                .andDo(print())
+                .andExpect(jsonPath("$.code").value(ErrorCode.INVALID_INPUT.getCode()))
+                .andExpect(jsonPath("$.message").value(ErrorCode.INVALID_INPUT.getMessage()))
+                .andExpect(jsonPath("$.data.time")
+                        .value("값의 형식이 올바르지 않습니다. (입력값: " + invalidTime + ")"));
+    }
+}

--- a/src/test/java/pyws/swyp/meeting/service/MeetingConfirmServiceTest.java
+++ b/src/test/java/pyws/swyp/meeting/service/MeetingConfirmServiceTest.java
@@ -1,0 +1,238 @@
+package pyws.swyp.meeting.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import pyws.swyp.global.error.CustomException;
+import pyws.swyp.global.error.ErrorCode;
+import pyws.swyp.meeting.entity.Meeting;
+import pyws.swyp.meeting.entity.MeetingParticipant;
+import pyws.swyp.meeting.entity.MeetingStatus;
+import pyws.swyp.meeting.entity.ParticipantRole;
+import pyws.swyp.meeting.entity.vote.DateVote;
+import pyws.swyp.meeting.entity.vote.TimeVote;
+import pyws.swyp.meeting.repository.MeetingParticipantRepository;
+import pyws.swyp.meeting.repository.MeetingRepository;
+import pyws.swyp.meeting.repository.vote.DateVoteRepository;
+import pyws.swyp.meeting.repository.vote.TimeVoteRepository;
+import pyws.swyp.member.entity.CharacterType;
+import pyws.swyp.member.entity.Gender;
+import pyws.swyp.member.entity.Member;
+import pyws.swyp.member.entity.MemberRole;
+import pyws.swyp.member.repository.MemberRepository;
+
+@SpringBootTest
+class MeetingConfirmServiceTest {
+
+    @Autowired
+    MeetingConfirmService meetingConfirmService;
+
+    @Autowired
+    MeetingRepository meetingRepository;
+    @Autowired
+    MeetingParticipantRepository meetingParticipantRepository;
+    @Autowired
+    DateVoteRepository dateVoteRepository;
+    @Autowired
+    TimeVoteRepository timeVoteRepository;
+    @Autowired
+    MemberRepository memberRepository;
+
+    private Long hostMemberId;
+    private Long normalMemberId;
+    private Long meetingId;
+    private Meeting meeting;
+
+    @BeforeEach
+    void setUp() {
+        dateVoteRepository.deleteAll();
+        timeVoteRepository.deleteAll();
+        meetingParticipantRepository.deleteAll();
+        meetingRepository.deleteAll();
+        memberRepository.deleteAll();
+
+        Meeting meeting = Meeting.builder()
+                .title("테스트 모임")
+                .build();
+        meeting.updateStatus(MeetingStatus.DATE_VOTING);
+        meetingRepository.save(meeting);
+        this.meetingId = meeting.getId();
+        this.meeting = meeting;
+
+        Member host = Member.builder()
+                .email("host@test.com")
+                .nickname("host")
+                .birthDate(LocalDate.now())
+                .gender(Gender.MALE)
+                .role(MemberRole.MEMBER)
+                .characterType(CharacterType.ACTIVE)
+                .build();
+        Member member = Member.builder()
+                .email("member@test.com")
+                .nickname("member")
+                .birthDate(LocalDate.now())
+                .gender(Gender.MALE)
+                .role(MemberRole.MEMBER)
+                .characterType(CharacterType.ACTIVE)
+                .build();
+
+        memberRepository.save(host);
+        memberRepository.save(member);
+
+        this.hostMemberId = host.getId();
+        this.normalMemberId = member.getId();
+
+        MeetingParticipant hostParticipant = MeetingParticipant.builder()
+                .meeting(meeting)
+                .member(host)
+                .role(ParticipantRole.HOST)
+                .build();
+
+        MeetingParticipant participant = MeetingParticipant.builder()
+                .meeting(meeting)
+                .member(member)
+                .role(ParticipantRole.MEMBER)
+                .build();
+
+        meetingParticipantRepository.save(hostParticipant);
+        meetingParticipantRepository.save(participant);
+
+        DateVote dateVote = DateVote.builder()
+                .meeting(meeting)
+                .meetingParticipant(hostParticipant)
+                .date(LocalDate.of(2025, 1, 1))
+                .build();
+        dateVoteRepository.save(dateVote);
+
+        TimeVote timevote = TimeVote.builder()
+                .meeting(meeting)
+                .meetingParticipant(participant)
+                .time(LocalTime.of(15, 30))
+                .build();
+        timeVoteRepository.save(timevote);
+    }
+
+    @Test
+    @DisplayName("모임장이 최다 득표 날짜로 확정하면 상태가 DATE_VOTED가 된다.")
+    void confirmDateVote_success() {
+        // when
+        meetingConfirmService.confirmDateVote(hostMemberId, meetingId);
+
+        // then
+        Meeting meeting = meetingRepository.findById(meetingId).orElseThrow();
+        assertEquals(MeetingStatus.DATE_VOTED, meeting.getStatus());
+        assertEquals(LocalDate.of(2025, 1, 1), meeting.getDate());
+    }
+
+    @Test
+    @DisplayName("모임장이 지정한 날짜로 확정하면 상태가 DATE_VOTED가 된다.")
+    void confirmDate_manual_success() {
+        // given
+        LocalDate chosen = LocalDate.of(2025, 2, 2);
+
+        // when
+        meetingConfirmService.confirmDate(hostMemberId, meetingId, chosen);
+
+        // then
+        Meeting meeting = meetingRepository.findById(meetingId).orElseThrow();
+        assertEquals(MeetingStatus.DATE_VOTED, meeting.getStatus());
+        assertEquals(chosen, meeting.getDate());
+    }
+
+    @Test
+    @DisplayName("모임장이 모임 날짜 확정을 취소하면 상태가 DATE_VOTING으로 바뀌고 확정 날짜가 null이 된다.")
+    void cancelConfirmDateVote_success() {
+        // given: 먼저 확정 상태 만들기
+        meetingConfirmService.confirmDateVote(hostMemberId, meetingId);
+
+        // when
+        meetingConfirmService.cancelConfirmDateVote(hostMemberId, meetingId);
+
+        // then
+        Meeting meeting = meetingRepository.findById(meetingId).orElseThrow();
+        assertEquals(MeetingStatus.DATE_VOTING, meeting.getStatus());
+        assertNull(meeting.getDate());
+    }
+
+    @Test
+    @DisplayName("모임장이 최다 득표 시간으로 확정하면 상태가 TIME_VOTED가 된다.")
+    void confirmTimeVote_success() {
+        // given
+        meeting.updateStatus(MeetingStatus.TIME_VOTING);
+        meetingRepository.save(meeting);
+
+        // when
+        meetingConfirmService.confirmTimeVote(hostMemberId, meetingId);
+
+        // then
+        Meeting updated = meetingRepository.findById(meetingId).orElseThrow();
+        assertEquals(MeetingStatus.TIME_VOTED, updated.getStatus());
+        assertEquals(LocalTime.of(15, 30), updated.getTime());
+    }
+
+    @Test
+    @DisplayName("모임장이 지정한 시간으로 확정하면 상태가 TIME_VOTED가 된다.")
+    void confirmTime_manual_success() {
+        // given
+        meeting.updateStatus(MeetingStatus.TIME_VOTING);
+        meetingRepository.save(meeting);
+
+        LocalTime chosen = LocalTime.of(20, 0);
+
+        // when
+        meetingConfirmService.confirmTime(hostMemberId, meetingId, chosen);
+
+        // then
+        Meeting updated = meetingRepository.findById(meetingId).orElseThrow();
+        assertEquals(MeetingStatus.TIME_VOTED, updated.getStatus());
+        assertEquals(chosen, updated.getTime());
+    }
+
+    @Test
+    @DisplayName("모임장이 모임 시간 확정을 취소하면 TIME_VOTING으로 바뀌고 확정 시간은 null이 된다.")
+    void cancelConfirmTimeVote_success() {
+        // given
+        meeting.updateStatus(MeetingStatus.TIME_VOTING);
+        meetingRepository.save(meeting);
+
+        meetingConfirmService.confirmTime(hostMemberId, meetingId, LocalTime.of(20, 0));
+
+        // when
+        meetingConfirmService.cancelConfirmTimeVote(hostMemberId, meetingId);
+
+        // then
+        Meeting updated = meetingRepository.findById(meetingId).orElseThrow();
+        assertEquals(MeetingStatus.TIME_VOTING, updated.getStatus());
+        assertNull(updated.getTime());
+    }
+
+    @Test
+    @DisplayName("모임장이 아니면 MEETING_HOST_ONLY 예외가 발생한다.")
+    void notHost_throw() {
+        // expected
+        CustomException ex = assertThrows(CustomException.class,
+                () -> meetingConfirmService.confirmDateVote(normalMemberId, meetingId));
+
+        assertEquals(ErrorCode.MEETING_HOST_ONLY, ex.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("모임이 투표 중 상태가 아니면 MEETING_NOT_CONFIRMABLE 예외가 발생한다.")
+    void confirmDateVote_wrongStatus_throw() {
+        // given
+        meeting.updateStatus(MeetingStatus.CREATED);
+        meetingRepository.save(meeting);
+
+        // expected
+        CustomException ex = assertThrows(CustomException.class,
+                () -> meetingConfirmService.confirmDateVote(hostMemberId, meetingId));
+
+        assertEquals(ErrorCode.MEETING_NOT_CONFIRMABLE, ex.getErrorCode());
+    }
+}


### PR DESCRIPTION
### 📌 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- 기능 추가

### 📌 관련 이슈
#27

### ✨ 반영 브랜치
feat/27 -> develop

### 📝 변경 사항
- [x] 모임장이 날짜 투표 결과를 기반으로 날짜를 확정하는 기능 추가
  - 동점 시 최다 득표 후보 중 가장 과거 날짜로 확정
- [x] 모임장이 날짜를 직접 지정하여 수동 확정하는 기능 추가
- [x] 확정된 날짜를 취소하는 기능 추가
- [x] 모임장이 시간 투표 결과를 기반으로 시간을 확정하는 기능 추가
  - 동점 시 최다 득표 후보 중 가장 이른 시간으로 확정
- [x] 모임장이 시간을 직접 지정하여 수동 확정하는 기능 추가
- [x] 확정된 시간을 취소하는 기능 추가
- [x] 날짜/시간 확정 관련 API Swagger 문서 추가
- [x] 날짜/시간 확정/취소 테스트 추가 

### 🐛 테스트 결과
<img width="591" height="361" alt="image" src="https://github.com/user-attachments/assets/68a0ad54-0d73-46d6-be8c-744863a8ce3b" />

