### PR TITLE
feat: #26 회원 탈퇴 시 연관 데이터 cascade 삭제 처리

### DIFF
--- a/src/main/java/pyws/swyp/global/error/ErrorCode.java
+++ b/src/main/java/pyws/swyp/global/error/ErrorCode.java
@@ -38,6 +38,7 @@ public enum ErrorCode {
     MEETING_PARTICIPANT_NOT_FOUND(NOT_FOUND, "MEET0006", "존재하지 않는 모임원입니다."),
     MEETING_HOST_ONLY(HttpStatus.FORBIDDEN, "MEET0007", "모임장만 투표 확정 및 취소를 할 수 있습니다."),
     MEETING_NOT_CONFIRMABLE(HttpStatus.BAD_REQUEST, "MEET0008", "현재 모임 상태에서는 투표 확정 또는 취소를 할 수 없습니다."),
+    HOST_CANNOT_WITHDRAW_WITH_UNCOMPLETED_MEETING(HttpStatus.BAD_REQUEST, "MEET0009", "완료되지 않은 모임의 모임장은 탈퇴할 수 없습니다."),
 
     // Vote
     DATE_VOTE_NOT_FOUND(NOT_FOUND, "VOTE0001", "아직 시간 투표가 존재하지 않습니다."),

--- a/src/main/java/pyws/swyp/meeting/repository/MeetingParticipantRepository.java
+++ b/src/main/java/pyws/swyp/meeting/repository/MeetingParticipantRepository.java
@@ -2,6 +2,7 @@ package pyws.swyp.meeting.repository;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import pyws.swyp.meeting.dto.MeetingBriefResponse;
@@ -85,4 +86,29 @@ public interface MeetingParticipantRepository extends JpaRepository<MeetingParti
     List<ParticipantRow> findByMeetingIds(@Param("meetingIds") List<Long> meetingIds);
 
     boolean existsByMemberIdAndMeetingId(Long memberId, Long meetingId);
+
+    @Query("""
+            select (count(mp) > 0)
+            from MeetingParticipant mp
+            join mp.meeting m
+            where mp.member.id = :memberId
+              and mp.role = 'HOST'
+              and m.status <> 'DONE'
+              and m.isActive = true
+            """)
+    boolean existsHostInUncompletedMeetings(Long memberId);
+
+    @Query("""
+            select mp.id
+            from MeetingParticipant mp
+            where mp.member.id = :memberId
+            """)
+    List<Long> findIdsByMemberId(Long memberId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+        delete from MeetingParticipant mp
+        where mp.id in :participantIds
+    """)
+    int deleteAllByIds(List<Long> participantIds);
 }

--- a/src/main/java/pyws/swyp/meeting/repository/vote/DateVoteRepository.java
+++ b/src/main/java/pyws/swyp/meeting/repository/vote/DateVoteRepository.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import pyws.swyp.meeting.dto.vote.VoterResponse;
 import pyws.swyp.meeting.entity.vote.DateVote;
@@ -54,5 +55,12 @@ public interface DateVoteRepository extends JpaRepository<DateVote, Long> {
             order by m.id asc
             """)
     List<VoterResponse> findVotersByMeetingIdAndDate(Long meetingId, LocalDate date);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            delete from DateVote dv
+            where dv.meetingParticipant.id in :participantIds
+            """)
+    void deleteAllByParticipantIds(List<Long> participantIds);
 }
 

--- a/src/main/java/pyws/swyp/meeting/repository/vote/TimeVoteRepository.java
+++ b/src/main/java/pyws/swyp/meeting/repository/vote/TimeVoteRepository.java
@@ -4,6 +4,7 @@ import java.time.LocalTime;
 import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import pyws.swyp.meeting.dto.vote.time.VotedTimeResponse;
 import pyws.swyp.meeting.dto.vote.VoterResponse;
@@ -67,4 +68,11 @@ public interface TimeVoteRepository extends JpaRepository<TimeVote, Long> {
             order by tv.time asc
             """)
     List<LocalTime> findVotedTimesByMeetingId(Long meetingId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            delete from TimeVote tv
+            where tv.meetingParticipant.id in :participantIds
+            """)
+    void deleteAllByParticipantIds(List<Long> participantIds);
 }

--- a/src/main/java/pyws/swyp/member/repository/SocialAccountRepository.java
+++ b/src/main/java/pyws/swyp/member/repository/SocialAccountRepository.java
@@ -3,6 +3,8 @@ package pyws.swyp.member.repository;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import pyws.swyp.member.entity.Member;
 import pyws.swyp.member.entity.SocialAccount;
 import pyws.swyp.member.entity.SocialProvider;
@@ -14,4 +16,8 @@ public interface SocialAccountRepository extends JpaRepository<SocialAccount, Lo
     List<SocialAccount> findByMember(Member member);
 
     Optional<SocialAccount> findByMemberIdAndSocialProvider(Long memberId, SocialProvider socialProvider);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("delete from SocialAccount sa where sa.member.id = :memberId")
+    int deleteAllByMemberId(Long memberId);
 }

--- a/src/main/java/pyws/swyp/member/service/MemberService.java
+++ b/src/main/java/pyws/swyp/member/service/MemberService.java
@@ -1,5 +1,6 @@
 package pyws.swyp.member.service;
 
+import static pyws.swyp.global.error.ErrorCode.HOST_CANNOT_WITHDRAW_WITH_UNCOMPLETED_MEETING;
 import static pyws.swyp.global.error.ErrorCode.MEMBER_NOT_FOUND;
 
 import java.util.List;
@@ -7,13 +8,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import pyws.swyp.auth.service.JwtService;
+import pyws.swyp.meeting.repository.MeetingParticipantRepository;
 import pyws.swyp.member.dto.MemberResponse;
 import pyws.swyp.member.dto.MemberWithdrawRequest;
 import pyws.swyp.member.dto.SocialAccountInfo;
 import pyws.swyp.member.entity.CharacterType;
 import pyws.swyp.member.entity.Member;
 import pyws.swyp.member.entity.MemberWithdrawal;
-import pyws.swyp.member.entity.SocialAccount;
 import pyws.swyp.member.repository.MemberRepository;
 import pyws.swyp.member.repository.MemberWithdrawalRepository;
 import pyws.swyp.member.repository.SocialAccountRepository;
@@ -25,6 +26,8 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final SocialAccountRepository socialAccountRepository;
     private final MemberWithdrawalRepository memberWithdrawalRepository;
+    private final MeetingParticipantRepository meetingParticipantRepository;
+    private final MemberWithdrawCleanupService memberWithdrawCleanupService;
     private final JwtService jwtService;
 
     @Transactional(readOnly = true)
@@ -53,6 +56,11 @@ public class MemberService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(MEMBER_NOT_FOUND::toException);
 
+        // 완료되지 않은 모임의 HOST는 탈퇴 불가
+        if (meetingParticipantRepository.existsHostInUncompletedMeetings(memberId)) {
+            throw HOST_CANNOT_WITHDRAW_WITH_UNCOMPLETED_MEETING.toException();
+        }
+
         // 탈퇴 사유 저장
         MemberWithdrawal memberWithdrawal = MemberWithdrawal.builder()
                 .type(request.type())
@@ -61,14 +69,16 @@ public class MemberService {
         memberWithdrawalRepository.save(memberWithdrawal);
 
         // 연동된 소셜 계정 정리
-        List<SocialAccount> socialAccounts = socialAccountRepository.findByMember(member);
-        socialAccountRepository.deleteAll(socialAccounts);
+        socialAccountRepository.deleteAllByMemberId(memberId);
 
-        // 회원 탈퇴 처리
-        memberRepository.delete(member);
+        // 연관된 자식 제거
+        memberWithdrawCleanupService.cleanup(memberId);
 
         // 로그아웃
         jwtService.logout(memberId);
+
+        // 회원 삭제
+        memberRepository.delete(member);
     }
 
     @Transactional

--- a/src/main/java/pyws/swyp/member/service/MemberWithdrawCleanupService.java
+++ b/src/main/java/pyws/swyp/member/service/MemberWithdrawCleanupService.java
@@ -1,0 +1,31 @@
+package pyws.swyp.member.service;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import pyws.swyp.meeting.repository.MeetingParticipantRepository;
+import pyws.swyp.meeting.repository.vote.DateVoteRepository;
+import pyws.swyp.meeting.repository.vote.TimeVoteRepository;
+
+@Service
+@RequiredArgsConstructor
+public class MemberWithdrawCleanupService {
+
+    private final MeetingParticipantRepository meetingParticipantRepository;
+    private final DateVoteRepository dateVoteRepository;
+    private final TimeVoteRepository timeVoteRepository;
+
+    @Transactional
+    public void cleanup(Long memberId) {
+        List<Long> participantIds = meetingParticipantRepository.findIdsByMemberId(memberId);
+        if (participantIds.isEmpty()) {
+            return;
+        }
+
+        dateVoteRepository.deleteAllByParticipantIds(participantIds);
+        timeVoteRepository.deleteAllByParticipantIds(participantIds);
+        meetingParticipantRepository.deleteAllByIds(participantIds);
+    }
+}
+

--- a/src/test/java/pyws/swyp/member/service/MemberServiceTest.java
+++ b/src/test/java/pyws/swyp/member/service/MemberServiceTest.java
@@ -1,6 +1,7 @@
 package pyws.swyp.member.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -9,15 +10,29 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.support.TransactionTemplate;
 import pyws.swyp.auth.service.JwtService;
 import pyws.swyp.global.error.CustomException;
+import pyws.swyp.global.error.ErrorCode;
+import pyws.swyp.meeting.entity.Meeting;
+import pyws.swyp.meeting.entity.MeetingParticipant;
+import pyws.swyp.meeting.entity.MeetingStatus;
+import pyws.swyp.meeting.entity.ParticipantRole;
+import pyws.swyp.meeting.entity.vote.DateVote;
+import pyws.swyp.meeting.entity.vote.TimeVote;
+import pyws.swyp.meeting.repository.MeetingParticipantRepository;
+import pyws.swyp.meeting.repository.MeetingRepository;
+import pyws.swyp.meeting.repository.vote.DateVoteRepository;
+import pyws.swyp.meeting.repository.vote.TimeVoteRepository;
 import pyws.swyp.member.dto.MemberResponse;
 import pyws.swyp.member.dto.MemberWithdrawRequest;
 import pyws.swyp.member.dto.SocialAccountInfo;
@@ -41,26 +56,44 @@ class MemberServiceTest {
 
     @Autowired
     MemberRepository memberRepository;
-
     @Autowired
     SocialAccountRepository socialAccountRepository;
-
     @Autowired
     MemberWithdrawalRepository memberWithdrawalRepository;
+    @Autowired
+    MeetingRepository meetingRepository;
+    @Autowired
+    MeetingParticipantRepository meetingParticipantRepository;
+    @Autowired
+    DateVoteRepository dateVoteRepository;
+    @Autowired
+    TimeVoteRepository timeVoteRepository;
 
     @MockitoBean
     JwtService jwtService;
 
-    private Member savedMember;
+    private Long memberId;
+    private Member member;
+
+    private Long meetingId;
+    private Meeting meeting;
+
+    private Long participantId;
+    private MeetingParticipant participant;
+
     private List<SocialAccount> savedSocialAccounts;
 
     @BeforeEach
     void setUp() {
-        memberWithdrawalRepository.deleteAll();
+        dateVoteRepository.deleteAll();
+        timeVoteRepository.deleteAll();
+        meetingParticipantRepository.deleteAll();
+        meetingRepository.deleteAll();
         socialAccountRepository.deleteAll();
+        memberWithdrawalRepository.deleteAll();
         memberRepository.deleteAll();
 
-        this.savedMember = memberRepository.save(Member.builder()
+        this.member = memberRepository.save(Member.builder()
                 .email("test@example.com")
                 .nickname("테스트")
                 .birthDate(LocalDate.of(1999, 1, 1))
@@ -68,15 +101,16 @@ class MemberServiceTest {
                 .role(MemberRole.MEMBER)
                 .characterType(CharacterType.ACTIVE)
                 .build());
+        this.memberId = member.getId();
 
         List<SocialAccount> socialAccounts = List.of(
                 SocialAccount.builder()
-                        .member(savedMember)
+                        .member(member)
                         .socialProvider(SocialProvider.KAKAO)
                         .socialId("kakao-1")
                         .build(),
                 SocialAccount.builder()
-                        .member(savedMember)
+                        .member(member)
                         .socialProvider(SocialProvider.NAVER)
                         .socialId("naver-1")
                         .build()
@@ -84,13 +118,40 @@ class MemberServiceTest {
 
         socialAccountRepository.saveAll(socialAccounts);
         this.savedSocialAccounts = socialAccounts;
+
+        meeting = Meeting.builder()
+                .title("테스트 모임")
+                .build();
+        meeting.updateStatus(MeetingStatus.DATE_VOTING);
+        meetingRepository.save(meeting);
+        this.meetingId = meeting.getId();
+
+        participant = MeetingParticipant.builder()
+                .meeting(meeting)
+                .member(member)
+                .role(ParticipantRole.MEMBER)
+                .build();
+        meetingParticipantRepository.save(participant);
+        this.participantId = participant.getId();
+
+        dateVoteRepository.save(DateVote.builder()
+                .meeting(meeting)
+                .meetingParticipant(participant)
+                .date(LocalDate.of(2025, 1, 1))
+                .build());
+
+        timeVoteRepository.save(TimeVote.builder()
+                .meeting(meeting)
+                .meetingParticipant(participant)
+                .time(LocalTime.of(15, 30))
+                .build());
     }
 
     @Test
     @DisplayName("로그인 정보를 조회한다.")
     void getMe_success() {
         // when
-        MemberResponse response = memberService.getMe(savedMember.getId());
+        MemberResponse response = memberService.getMe(member.getId());
 
         // then
         assertEquals("test@example.com", response.email());
@@ -114,23 +175,92 @@ class MemberServiceTest {
     }
 
     @Test
-    @DisplayName("탈퇴 시 탈퇴사유 저장, 소셜 계정 삭제, 회원 삭제, 로그아웃 호출")
-    void withdraw_success() {
+    @DisplayName("회원 탈퇴 시 탈퇴사유 저장, 소셜 계정 삭제, 투표/참여자 정리, 회원 삭제, 로그아웃 호출")
+    void withdraw_success_cascade() {
         // given
         MemberWithdrawRequest request = new MemberWithdrawRequest(WithdrawalType.BUG, null);
 
         // when
-        memberService.withdraw(savedMember.getId(), request);
+        memberService.withdraw(memberId, request);
 
         // then
-        assertTrue(memberRepository.findById(savedMember.getId()).isEmpty());
-        assertEquals(0, socialAccountRepository.count());
+        Optional<Member> findMember = memberRepository.findById(memberId);
+        assertTrue(findMember.isEmpty());
 
         List<MemberWithdrawal> withdrawals = memberWithdrawalRepository.findAll();
         assertEquals(1, withdrawals.size());
         assertEquals(WithdrawalType.BUG, withdrawals.getFirst().getType());
 
-        verify(jwtService, times(1)).logout(savedMember.getId());
+        assertEquals(0, socialAccountRepository.count());
+
+        assertFalse(meetingParticipantRepository.existsById(participantId));
+        assertEquals(0, dateVoteRepository.count());
+        assertEquals(0, timeVoteRepository.count());
+
+        verify(jwtService, times(1)).logout(memberId);
+    }
+
+    @Test
+    @DisplayName("완료되지 않은 모임 HOST는 탈퇴 불가 + 로그아웃 미호출")
+    void withdraw_denied_whenHostInUncompletedMeeting() {
+        // given
+        MeetingParticipant host = MeetingParticipant.builder()
+                .meeting(meeting)
+                .member(member)
+                .role(ParticipantRole.HOST)
+                .build();
+        meetingParticipantRepository.save(host);
+
+        MemberWithdrawRequest request = new MemberWithdrawRequest(WithdrawalType.ETC, "테스트");
+
+        // when
+        CustomException ex = assertThrows(CustomException.class,
+                () -> memberService.withdraw(memberId, request));
+
+        // then
+        assertEquals(ErrorCode.HOST_CANNOT_WITHDRAW_WITH_UNCOMPLETED_MEETING, ex.getErrorCode());
+
+        verify(jwtService, never()).logout(anyLong());
+        assertTrue(memberRepository.existsById(memberId));
+    }
+
+    @Test
+    @DisplayName("완료된 모임일 때는 HOST도 회원 탈퇴가 가능하다.")
+    void withdraw_success_whenHostAndMeetingCompleted() {
+        // given
+        Meeting completed = Meeting.builder()
+                .title("완료된 모임")
+                .build();
+        completed.updateStatus(MeetingStatus.DONE);
+        meetingRepository.save(completed);
+
+        MeetingParticipant host = MeetingParticipant.builder()
+                .meeting(completed)
+                .member(member)
+                .role(ParticipantRole.HOST)
+                .build();
+        meetingParticipantRepository.save(host);
+
+        MemberWithdrawRequest request = new MemberWithdrawRequest(WithdrawalType.ETC, "테스트");
+
+        // when
+        memberService.withdraw(memberId, request);
+
+        // then
+        Optional<Member> findMember = memberRepository.findById(memberId);
+        assertTrue(findMember.isEmpty());
+
+        List<MemberWithdrawal> withdrawals = memberWithdrawalRepository.findAll();
+        assertEquals(1, withdrawals.size());
+        assertEquals(WithdrawalType.ETC, withdrawals.getFirst().getType());
+
+        assertEquals(0, socialAccountRepository.count());
+
+        assertFalse(meetingParticipantRepository.existsById(participantId));
+        assertEquals(0, dateVoteRepository.count());
+        assertEquals(0, timeVoteRepository.count());
+
+        verify(jwtService, times(1)).logout(memberId);
     }
 
     @Test
@@ -154,10 +284,10 @@ class MemberServiceTest {
         CharacterType characterType = CharacterType.CULTURE_LOVER;
 
         //when
-        memberService.updateCharacter(savedMember.getId(), characterType);
+        memberService.updateCharacter(member.getId(), characterType);
 
         //then
-        Member member = memberRepository.findById(this.savedMember.getId()).get();
+        Member member = memberRepository.findById(this.member.getId()).get();
         assertEquals(characterType, member.getCharacterType());
     }
 }

--- a/src/test/java/pyws/swyp/member/service/SocialAccountServiceTest.java
+++ b/src/test/java/pyws/swyp/member/service/SocialAccountServiceTest.java
@@ -13,6 +13,10 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import pyws.swyp.auth.service.JwtService;
 import pyws.swyp.global.error.CustomException;
 import pyws.swyp.global.error.ErrorCode;
+import pyws.swyp.meeting.repository.MeetingParticipantRepository;
+import pyws.swyp.meeting.repository.MeetingRepository;
+import pyws.swyp.meeting.repository.vote.DateVoteRepository;
+import pyws.swyp.meeting.repository.vote.TimeVoteRepository;
 import pyws.swyp.member.dto.SocialLinkRequest;
 import pyws.swyp.member.entity.CharacterType;
 import pyws.swyp.member.entity.Gender;
@@ -31,9 +35,16 @@ class SocialAccountServiceTest {
 
     @Autowired
     MemberRepository memberRepository;
-
     @Autowired
     SocialAccountRepository socialAccountRepository;
+    @Autowired
+    MeetingRepository meetingRepository;
+    @Autowired
+    MeetingParticipantRepository meetingParticipantRepository;
+    @Autowired
+    DateVoteRepository dateVoteRepository;
+    @Autowired
+    TimeVoteRepository timeVoteRepository;
 
     @MockitoBean
     JwtService jwtService;
@@ -42,6 +53,10 @@ class SocialAccountServiceTest {
 
     @BeforeEach
     void setUp() {
+        dateVoteRepository.deleteAll();
+        timeVoteRepository.deleteAll();
+        meetingParticipantRepository.deleteAll();
+        meetingRepository.deleteAll();
         socialAccountRepository.deleteAll();
         memberRepository.deleteAll();
 


### PR DESCRIPTION
### 📌 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- 기능 추가
- 버그 수정

### 📌 관련 이슈
#26 

### ✨ 반영 브랜치
feat/26 -> develop

### 📝 변경 사항
- [x] 회원 탈퇴 시 연관 데이터 Cascade 삭제 로직 추가
  - `Member → MeetingParticipant → DateVote / TimeVote` 
- [x] 완료되지 않은 모임의 HOST는 회원 탈퇴 제한
- [x] 회원 탈퇴 테스트 추가

### ➕ 추가 메모
- 모임이 완료되기 전에는 모임장은 탈퇴를 제한

<img width="284" height="594" alt="image" src="https://github.com/user-attachments/assets/4ed79194-dc77-411f-a28a-535819ef5e73" />

- 모임이 완료되면 모임장도 탈퇴 가능
  - 완료 후에는 `Meeting`의 확정된 정보만 필요하므로 `MeetingParticipant` 및 투표 데이터 물리 삭제 가능

### 🐛 테스트 결과
<img width="588" height="122" alt="image" src="https://github.com/user-attachments/assets/ee6f33a0-3540-4114-baea-f07b0b297883" />
