### PR TITLE
refactor: #42 meeting 생성 API request, response 수정

### DIFF
--- a/src/main/java/pyws/swyp/meeting/controller/MeetingController.java
+++ b/src/main/java/pyws/swyp/meeting/controller/MeetingController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.*;
 import pyws.swyp.meeting.controller.api.MeetingApi;
 import pyws.swyp.meeting.dto.MeetingBriefResponse;
 import pyws.swyp.meeting.dto.MeetingCreateRequest;
+import pyws.swyp.meeting.dto.MeetingCreateResponse;
 import pyws.swyp.meeting.dto.MeetingUpdateRequest;
 import pyws.swyp.meeting.service.MeetingService;
 
@@ -22,8 +23,8 @@ public class MeetingController implements MeetingApi {
     private final MeetingService meetingService;
 
     @PostMapping
-    public void createMeeting(@AuthenticationPrincipal Long memberId, @RequestBody @Validated MeetingCreateRequest request) {
-        meetingService.createMeeting(memberId, request);
+    public MeetingCreateResponse createMeeting(@AuthenticationPrincipal Long memberId, @RequestBody @Validated MeetingCreateRequest request) {
+        return meetingService.createMeeting(memberId, request);
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/pyws/swyp/meeting/controller/api/MeetingApi.java
+++ b/src/main/java/pyws/swyp/meeting/controller/api/MeetingApi.java
@@ -1,6 +1,8 @@
 package pyws.swyp.meeting.controller.api;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -12,6 +14,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import pyws.swyp.meeting.dto.MeetingBriefResponse;
 import pyws.swyp.meeting.dto.MeetingCreateRequest;
+import pyws.swyp.meeting.dto.MeetingCreateResponse;
 import pyws.swyp.meeting.dto.MeetingUpdateRequest;
 
 import java.util.List;
@@ -26,14 +29,75 @@ public interface MeetingApi {
                     """
                             모임 생성 요청을 처리합니다.
                             모임 생성 시 생성한 사람을 모임의 HOST로 지정하여 저장합니다.
-                            title은 null & blank 불가합니다.
+                            title은 null & blank 불가하며 type은 null 불가합니다.
+                            
+                            사용 가능한 모임 타입
+                            - FOODIE (미식형)
+                            - DRINKER (음주형)
+                            - HEALER (휴식형)
+                            - CULTURE_LOVER (관람형)
+                            - TRAVELER (모험형)
+                            - ACTIVE (활동형)
+                            - TREND_SETTER (주목형)
+                            - STUDIER (학습형)
                     """
     )
     @ApiResponse(
             responseCode = "200",
-            description = "모임 생성 성공"
+            description = "모임 생성 성공",
+            content = @Content(
+                    mediaType = "application/json",
+                    examples = {
+                            @ExampleObject(
+                                    name = "모임 생성 성공",
+                                    value = """
+                                            {
+                                              "code": "SUCCESS",
+                                              "message": "요청이 성공적으로 처리되었습니다.",
+                                              "data": {
+                                                "meetingId": 3,
+                                                "title": "모잇 오프라인"
+                                              }
+                                            }
+                                            """
+                            )
+                    }
+            )
     )
-    void createMeeting(@AuthenticationPrincipal Long memberId, @RequestBody @Validated MeetingCreateRequest request);
+    @ApiResponse(
+            responseCode = "400",
+            description = "모임 또는 모임원 정보를 찾을 수 없음",
+            content = @Content(
+                    mediaType = "application/json",
+                    examples = {
+                            @ExampleObject(
+                                    name = "모임 타입 명칭 오류",
+                                    value = """
+                                            {
+                                              "code": "COM0001",
+                                              "message": "잘못된 요청입니다.",
+                                              "data": {
+                                                "type": "값의 형식이 올바르지 않습니다."
+                                              }
+                                            }
+                                            """
+                            ),
+                            @ExampleObject(
+                                    name = "모임 이름 blank",
+                                    value = """
+                                            {
+                                              "code": "COM0001",
+                                              "message": "잘못된 요청입니다.",
+                                              "data": {
+                                                "title": "모임명을 입력해 주세요."
+                                              }
+                                            }
+                                            """
+                            )
+                    }
+            )
+    )
+    MeetingCreateResponse createMeeting(@AuthenticationPrincipal Long memberId, @RequestBody @Validated MeetingCreateRequest request);
 
     @Operation(
             summary = "모임 삭제",

--- a/src/main/java/pyws/swyp/meeting/dto/MeetingCreateRequest.java
+++ b/src/main/java/pyws/swyp/meeting/dto/MeetingCreateRequest.java
@@ -2,24 +2,13 @@ package pyws.swyp.meeting.dto;
 
 
 import jakarta.validation.constraints.NotBlank;
-import pyws.swyp.meeting.entity.Meeting;
-
-import java.time.LocalDate;
-import java.time.LocalDateTime;
+import jakarta.validation.constraints.NotNull;
+import pyws.swyp.meeting.entity.MeetingType;
 
 public record MeetingCreateRequest(
         @NotBlank(message = "모임명을 입력해 주세요.")
         String title,
-        LocalDate date,
-        LocalDateTime dateVoteDeadline,
-        LocalDateTime courseVoteDeadline
+        @NotNull(message = "모임 유형을 선택해 주세요")
+        MeetingType type
 ) {
-    public Meeting toMeetingEntity() {
-        return Meeting.builder()
-                .title(this.title)
-                .date(this.date)
-                .dateVoteDeadline(this.dateVoteDeadline)
-                .courseVoteDeadline(this.courseVoteDeadline)
-                .build();
-    }
 }

--- a/src/main/java/pyws/swyp/meeting/dto/MeetingCreateResponse.java
+++ b/src/main/java/pyws/swyp/meeting/dto/MeetingCreateResponse.java
@@ -1,0 +1,7 @@
+package pyws.swyp.meeting.dto;
+
+public record MeetingCreateResponse(
+        Long meetingId,
+        String title
+) {
+}

--- a/src/main/java/pyws/swyp/meeting/dto/MeetingUpdateRequest.java
+++ b/src/main/java/pyws/swyp/meeting/dto/MeetingUpdateRequest.java
@@ -5,8 +5,6 @@ import java.time.LocalDateTime;
 
 public record MeetingUpdateRequest(
         String title,
-        LocalDate date,
-        LocalDateTime dateVoteDeadline,
-        LocalDateTime courseVoteDeadline
+        LocalDate date
 ) {
 }

--- a/src/main/java/pyws/swyp/meeting/entity/Meeting.java
+++ b/src/main/java/pyws/swyp/meeting/entity/Meeting.java
@@ -45,12 +45,6 @@ public class Meeting extends BaseEntity {
     @Column(nullable = false, length = 50)
     private MeetingType type;
 
-    @Column
-    private LocalDateTime dateVoteDeadline;
-
-    @Column
-    private LocalDateTime courseVoteDeadline;
-
     @Builder
     public Meeting(
             String title,
@@ -59,21 +53,6 @@ public class Meeting extends BaseEntity {
         this.title = title;
         this.type = type;
     }
-
-//    @Builder
-//    public Meeting(
-//            String title,
-//            LocalDate date,
-//            LocalTime time,
-//            LocalDateTime dateVoteDeadline,
-//            LocalDateTime courseVoteDeadline
-//    ) {
-//        this.title = title;
-//        this.date = date;
-//        this.time = time;
-//        this.dateVoteDeadline = dateVoteDeadline;
-//        this.courseVoteDeadline = courseVoteDeadline;
-//    }
 
     public void updateStatus(MeetingStatus status) {
         this.status = status;
@@ -88,12 +67,6 @@ public class Meeting extends BaseEntity {
         }
         if (request.date() != null) {
             this.date = request.date();
-        }
-        if (request.dateVoteDeadline() != null) {
-            this.dateVoteDeadline = request.dateVoteDeadline();
-        }
-        if (request.courseVoteDeadline() != null) {
-            this.courseVoteDeadline = request.courseVoteDeadline();
         }
     }
 

--- a/src/main/java/pyws/swyp/meeting/entity/Meeting.java
+++ b/src/main/java/pyws/swyp/meeting/entity/Meeting.java
@@ -38,8 +38,12 @@ public class Meeting extends BaseEntity {
     private LocalTime time;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
+    @Column(nullable = false, length = 50)
     private MeetingStatus status = MeetingStatus.CREATED;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 50)
+    private MeetingType type;
 
     @Column
     private LocalDateTime dateVoteDeadline;
@@ -50,17 +54,26 @@ public class Meeting extends BaseEntity {
     @Builder
     public Meeting(
             String title,
-            LocalDate date,
-            LocalTime time,
-            LocalDateTime dateVoteDeadline,
-            LocalDateTime courseVoteDeadline
+            MeetingType type
     ) {
         this.title = title;
-        this.date = date;
-        this.time = time;
-        this.dateVoteDeadline = dateVoteDeadline;
-        this.courseVoteDeadline = courseVoteDeadline;
+        this.type = type;
     }
+
+//    @Builder
+//    public Meeting(
+//            String title,
+//            LocalDate date,
+//            LocalTime time,
+//            LocalDateTime dateVoteDeadline,
+//            LocalDateTime courseVoteDeadline
+//    ) {
+//        this.title = title;
+//        this.date = date;
+//        this.time = time;
+//        this.dateVoteDeadline = dateVoteDeadline;
+//        this.courseVoteDeadline = courseVoteDeadline;
+//    }
 
     public void updateStatus(MeetingStatus status) {
         this.status = status;

--- a/src/main/java/pyws/swyp/meeting/entity/MeetingType.java
+++ b/src/main/java/pyws/swyp/meeting/entity/MeetingType.java
@@ -1,7 +1,6 @@
-package pyws.swyp.member.entity;
+package pyws.swyp.meeting.entity;
 
-public enum CharacterType {
-
+public enum MeetingType {
     FOODIE,        // 미식형
     DRINKER,       // 음주형
     HEALER,        // 휴식형

--- a/src/main/java/pyws/swyp/meeting/repository/MeetingParticipantRepository.java
+++ b/src/main/java/pyws/swyp/meeting/repository/MeetingParticipantRepository.java
@@ -53,7 +53,7 @@ public interface MeetingParticipantRepository extends JpaRepository<MeetingParti
     """)
     List<MeetingBriefResponse> findMeetingsByMemberIdAndStatus(
             @Param("memberId") Long memberId,
-            @Param("statuses")Collection<MeetingStatus> statuses,
+            @Param("statuses") Collection<MeetingStatus> statuses,
             Pageable pageable
     );
 

--- a/src/main/java/pyws/swyp/meeting/service/MeetingService.java
+++ b/src/main/java/pyws/swyp/meeting/service/MeetingService.java
@@ -9,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 import pyws.swyp.global.error.ErrorCode;
 import pyws.swyp.meeting.dto.MeetingBriefResponse;
 import pyws.swyp.meeting.dto.MeetingCreateRequest;
+import pyws.swyp.meeting.dto.MeetingCreateResponse;
 import pyws.swyp.meeting.dto.MeetingUpdateRequest;
 import pyws.swyp.meeting.entity.Meeting;
 import pyws.swyp.meeting.entity.MeetingParticipant;
@@ -30,17 +31,22 @@ public class MeetingService {
     private final MemberRepository memberRepository;
     private final ApplicationEventPublisher eventPublisher;
 
-    public void createMeeting(Long memberId, MeetingCreateRequest request) {
+    public MeetingCreateResponse createMeeting(Long memberId, MeetingCreateRequest request) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(ErrorCode.MEMBER_NOT_FOUND::toException);
 
-        Meeting meeting = request.toMeetingEntity();
+        Meeting meeting = Meeting.builder()
+                .title(request.title())
+                .type(request.type())
+                .build();
         meetingRepository.save(meeting);
 
         MeetingParticipant meetingParticipant = MeetingParticipant.host(meeting, member);
         meetingParticipantRepository.save(meetingParticipant);
 
         eventPublisher.publishEvent(new VoteStartedEvent(memberId));
+
+        return new MeetingCreateResponse(meeting.getId(), meeting.getTitle());
     }
 
     public void deleteMeeting(Long memberId, Long meetingId) {

--- a/src/main/java/pyws/swyp/member/controller/api/MemberApi.java
+++ b/src/main/java/pyws/swyp/member/controller/api/MemberApi.java
@@ -136,7 +136,7 @@ public interface MemberApi {
                             - TRAVELER (모험형)
                             - ACTIVE (활동형)
                             - TREND_SETTER (주목형)
-                            - STUDYER (학습형)
+                            - STUDIER (학습형)
                             
                             예) /api/members/me/CULTURE_LOVER
                             """

--- a/src/main/java/pyws/swyp/member/repository/friend/FriendshipRepository.java
+++ b/src/main/java/pyws/swyp/member/repository/friend/FriendshipRepository.java
@@ -13,7 +13,7 @@ public interface FriendshipRepository extends JpaRepository<Friendship, Long> {
             SELECT f
             FROM Friendship f
             WHERE f.member.id = :memberId
-                AND f.friend.id IN :meetingIds
+                AND f.friend.id IN :friendIds
     """)
     List<Friendship> findByMemberIdAndFriendIds(Long memberId, List<Long> friendIds);
 

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -13,10 +13,10 @@ SET FOREIGN_KEY_CHECKS = 0;
 ------------------------------------------------------
 
 -- MEETING
-INSERT IGNORE INTO meeting (id, public_id, created_at, is_active, updated_at, date, time, status, title)
+INSERT IGNORE INTO meeting (id, public_id, created_at, is_active, updated_at, date, time, status, type, title)
 VALUES
-    (1, UUID_TO_BIN(UUID()), NOW(), 1, NULL, '2025-12-20', NULL, 'CREATED', '연말 모임'),
-    (2, UUID_TO_BIN(UUID()), NOW(), 1, NULL, '2025-12-25', '19:00:00', 'PLACE_VOTING', '크리스마스 모임');
+    (1, UUID_TO_BIN(UUID()), NOW(), 1, NULL, '2025-12-20', NULL, 'CREATED', 'FOODIE', '연말 모임'),
+    (2, UUID_TO_BIN(UUID()), NOW(), 1, NULL, '2025-12-25', '19:00:00', 'PLACE_VOTING', 'TREND_SETTER','크리스마스 모임');
 
 -- MEMBER
 INSERT IGNORE INTO member (id, created_at, birth_date, email, gender, nickname, character_type, role)

--- a/src/test/java/pyws/swyp/meeting/controller/MeetingConfirmControllerTest.java
+++ b/src/test/java/pyws/swyp/meeting/controller/MeetingConfirmControllerTest.java
@@ -24,10 +24,7 @@ import pyws.swyp.config.AuthPrincipalTestConfig;
 import pyws.swyp.config.AuthTestPrincipalContext;
 import pyws.swyp.config.TestRedisConfig;
 import pyws.swyp.global.error.ErrorCode;
-import pyws.swyp.meeting.entity.Meeting;
-import pyws.swyp.meeting.entity.MeetingParticipant;
-import pyws.swyp.meeting.entity.MeetingStatus;
-import pyws.swyp.meeting.entity.ParticipantRole;
+import pyws.swyp.meeting.entity.*;
 import pyws.swyp.meeting.repository.MeetingParticipantRepository;
 import pyws.swyp.meeting.repository.MeetingRepository;
 import pyws.swyp.meeting.repository.vote.DateVoteRepository;
@@ -81,6 +78,7 @@ class MeetingConfirmControllerTest {
 
         Meeting meeting = meetingRepository.save(Meeting.builder()
                 .title("확정 테스트 모임")
+                .type(MeetingType.DRINKER)
                 .build());
         this.meetingId = meeting.getId();
 

--- a/src/test/java/pyws/swyp/meeting/controller/MeetingControllerTest.java
+++ b/src/test/java/pyws/swyp/meeting/controller/MeetingControllerTest.java
@@ -20,6 +20,7 @@ import pyws.swyp.config.AuthTestPrincipalContext;
 import pyws.swyp.global.jwt.JwtProvider;
 import pyws.swyp.meeting.dto.MeetingCreateRequest;
 import pyws.swyp.meeting.dto.MeetingUpdateRequest;
+import pyws.swyp.meeting.entity.MeetingType;
 import pyws.swyp.meeting.service.MeetingService;
 
 import java.time.LocalDate;
@@ -57,9 +58,7 @@ public class MeetingControllerTest {
 
         MeetingCreateRequest request = new MeetingCreateRequest(
                 "모잇 오프라인",
-                LocalDate.of(2025,12,30),
-                LocalDateTime.of(2025,12,15,23,59),
-                LocalDateTime.of(2025,12,26,23,59)
+                MeetingType.FOODIE
         );
 
         // when
@@ -83,9 +82,7 @@ public class MeetingControllerTest {
         // given
         MeetingCreateRequest request = new MeetingCreateRequest(
                 "  ",
-                LocalDate.of(2025,12,30),
-                LocalDateTime.of(2025,12,15,23,59),
-                LocalDateTime.of(2025,12,26,23,59)
+                MeetingType.FOODIE
         );
 
         // when

--- a/src/test/java/pyws/swyp/meeting/controller/MeetingControllerTest.java
+++ b/src/test/java/pyws/swyp/meeting/controller/MeetingControllerTest.java
@@ -189,9 +189,7 @@ public class MeetingControllerTest {
 
         MeetingUpdateRequest request = new MeetingUpdateRequest(
                 "모잇 오프라인",
-                LocalDate.of(2025,12,30),
-                LocalDateTime.of(2025,12,15,23,59),
-                LocalDateTime.of(2025,12,26,23,59)
+                LocalDate.of(2025,12,30)
         );
 
         // when
@@ -218,9 +216,7 @@ public class MeetingControllerTest {
 
         MeetingUpdateRequest request = new MeetingUpdateRequest(
                 "모잇 오프라인",
-                LocalDate.of(2025,12,30),
-                LocalDateTime.of(2025,12,15,23,59),
-                LocalDateTime.of(2025,12,26,23,59)
+                LocalDate.of(2025,12,30)
         );
 
         // when

--- a/src/test/java/pyws/swyp/meeting/controller/vote/DateVoteControllerTest.java
+++ b/src/test/java/pyws/swyp/meeting/controller/vote/DateVoteControllerTest.java
@@ -30,10 +30,7 @@ import pyws.swyp.config.AuthTestPrincipalContext;
 import pyws.swyp.config.TestRedisConfig;
 import pyws.swyp.global.error.ErrorCode;
 import pyws.swyp.meeting.dto.vote.date.DateVoteRequest;
-import pyws.swyp.meeting.entity.Meeting;
-import pyws.swyp.meeting.entity.MeetingParticipant;
-import pyws.swyp.meeting.entity.MeetingStatus;
-import pyws.swyp.meeting.entity.ParticipantRole;
+import pyws.swyp.meeting.entity.*;
 import pyws.swyp.meeting.entity.vote.DateVote;
 import pyws.swyp.meeting.repository.MeetingParticipantRepository;
 import pyws.swyp.meeting.repository.MeetingRepository;
@@ -103,6 +100,7 @@ class DateVoteControllerTest {
         // meeting
         Meeting meeting = meetingRepository.save(Meeting.builder()
                 .title("테스트 모임")
+                .type(MeetingType.DRINKER)
                 .build());
         meeting.updateStatus(MeetingStatus.CREATED);
         this.meetingId = meeting.getId();

--- a/src/test/java/pyws/swyp/meeting/controller/vote/TimeVoteControllerTest.java
+++ b/src/test/java/pyws/swyp/meeting/controller/vote/TimeVoteControllerTest.java
@@ -32,10 +32,7 @@ import pyws.swyp.config.AuthTestPrincipalContext;
 import pyws.swyp.config.TestRedisConfig;
 import pyws.swyp.global.error.ErrorCode;
 import pyws.swyp.meeting.dto.vote.time.TimeVoteRequest;
-import pyws.swyp.meeting.entity.Meeting;
-import pyws.swyp.meeting.entity.MeetingParticipant;
-import pyws.swyp.meeting.entity.MeetingStatus;
-import pyws.swyp.meeting.entity.ParticipantRole;
+import pyws.swyp.meeting.entity.*;
 import pyws.swyp.meeting.entity.vote.TimeVote;
 import pyws.swyp.meeting.repository.MeetingParticipantRepository;
 import pyws.swyp.meeting.repository.MeetingRepository;
@@ -104,6 +101,7 @@ class TimeVoteControllerTest {
         // meeting
         Meeting meeting = meetingRepository.save(Meeting.builder()
                 .title("테스트 모임")
+                .type(MeetingType.DRINKER)
                 .build());
         meeting.updateStatus(MeetingStatus.TIME_VOTING);
         meetingRepository.save(meeting);

--- a/src/test/java/pyws/swyp/meeting/service/HomeServiceTest.java
+++ b/src/test/java/pyws/swyp/meeting/service/HomeServiceTest.java
@@ -47,7 +47,7 @@ public class HomeServiceTest {
         ParticipantInfo p1 = new ParticipantInfo(memberId, "닉네임1", CharacterType.FOODIE, pyws.swyp.meeting.entity.ParticipantRole.HOST);
         ParticipantInfo p2 = new ParticipantInfo(2L, "닉네임2", CharacterType.TRAVELER, pyws.swyp.meeting.entity.ParticipantRole.MEMBER);
         ParticipantInfo p3 = new ParticipantInfo(3L, "닉네임3", CharacterType.HEALER, ParticipantRole.MEMBER);
-        ParticipantInfo p4 = new ParticipantInfo(4L, "닉네임4", CharacterType.STUDYER, pyws.swyp.meeting.entity.ParticipantRole.MEMBER);
+        ParticipantInfo p4 = new ParticipantInfo(4L, "닉네임4", CharacterType.STUDIER, pyws.swyp.meeting.entity.ParticipantRole.MEMBER);
         ParticipantInfo p5 = new ParticipantInfo(5L, "닉네임5", CharacterType.FOODIE, pyws.swyp.meeting.entity.ParticipantRole.MEMBER);
 
         List<ParticipantRow> participantRows = List.of(

--- a/src/test/java/pyws/swyp/meeting/service/MeetingConfirmServiceTest.java
+++ b/src/test/java/pyws/swyp/meeting/service/MeetingConfirmServiceTest.java
@@ -11,10 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import pyws.swyp.global.error.CustomException;
 import pyws.swyp.global.error.ErrorCode;
-import pyws.swyp.meeting.entity.Meeting;
-import pyws.swyp.meeting.entity.MeetingParticipant;
-import pyws.swyp.meeting.entity.MeetingStatus;
-import pyws.swyp.meeting.entity.ParticipantRole;
+import pyws.swyp.meeting.entity.*;
 import pyws.swyp.meeting.entity.vote.DateVote;
 import pyws.swyp.meeting.entity.vote.TimeVote;
 import pyws.swyp.meeting.repository.MeetingParticipantRepository;
@@ -59,6 +56,7 @@ class MeetingConfirmServiceTest {
 
         Meeting meeting = Meeting.builder()
                 .title("테스트 모임")
+                .type(MeetingType.DRINKER)
                 .build();
         meeting.updateStatus(MeetingStatus.DATE_VOTING);
         meetingRepository.save(meeting);

--- a/src/test/java/pyws/swyp/meeting/service/MeetingServiceTest.java
+++ b/src/test/java/pyws/swyp/meeting/service/MeetingServiceTest.java
@@ -338,9 +338,7 @@ public class MeetingServiceTest {
 
         MeetingUpdateRequest request = new MeetingUpdateRequest(
                 null,
-                LocalDate.of(2026,1,20),
-                null,
-                null
+                LocalDate.of(2026,1,20)
         );
 
         when(meetingRepository.findById(meetingId)).thenReturn(Optional.of(meeting));
@@ -374,9 +372,7 @@ public class MeetingServiceTest {
 
         MeetingUpdateRequest request = new MeetingUpdateRequest(
                 null,
-                LocalDate.of(2026,1,20),
-                null,
-                null
+                LocalDate.of(2026,1,20)
         );
 
         when(meetingRepository.findById(meetingId)).thenReturn(Optional.of(meeting));
@@ -412,9 +408,7 @@ public class MeetingServiceTest {
 
         MeetingUpdateRequest request = new MeetingUpdateRequest(
                 " ",
-                LocalDate.of(2026,1,20),
-                null,
-                null
+                LocalDate.of(2026,1,20)
         );
 
         when(meetingRepository.findById(meetingId)).thenReturn(Optional.of(meeting));

--- a/src/test/java/pyws/swyp/meeting/service/MeetingServiceTest.java
+++ b/src/test/java/pyws/swyp/meeting/service/MeetingServiceTest.java
@@ -26,15 +26,14 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
 import pyws.swyp.global.error.CustomException;
 import pyws.swyp.global.error.ErrorCode;
 import pyws.swyp.meeting.dto.MeetingBriefResponse;
 import pyws.swyp.meeting.dto.MeetingCreateRequest;
+import pyws.swyp.meeting.dto.MeetingCreateResponse;
 import pyws.swyp.meeting.dto.MeetingUpdateRequest;
-import pyws.swyp.meeting.entity.Meeting;
-import pyws.swyp.meeting.entity.MeetingParticipant;
-import pyws.swyp.meeting.entity.MeetingStatus;
-import pyws.swyp.meeting.entity.ParticipantRole;
+import pyws.swyp.meeting.entity.*;
 import pyws.swyp.meeting.repository.MeetingParticipantRepository;
 import pyws.swyp.meeting.repository.MeetingRepository;
 import pyws.swyp.member.entity.CharacterType;
@@ -68,14 +67,7 @@ public class MeetingServiceTest {
     void 모임_생성_성공() {
         // given
         Long memberId = 1L;
-        MeetingCreateRequest request = mock(MeetingCreateRequest.class);
-        Meeting meeting = Meeting.builder()
-                .title("테스트 모임 생성")
-                .date(nowDate.plusDays(7))
-                .dateVoteDeadline(nowDateTime.plusDays(1))
-                .courseVoteDeadline(nowDateTime.plusDays(3))
-                .build();
-        when(request.toMeetingEntity()).thenReturn(meeting);
+        MeetingCreateRequest request = new MeetingCreateRequest("테스트 모임 생성", MeetingType.DRINKER);
 
         Member member = new Member(
                 "1234@example.com",
@@ -85,21 +77,38 @@ public class MeetingServiceTest {
                 MemberRole.MEMBER,
                 CharacterType.TRAVELER
                 );
-        // Todo: 추후 변경된 로직에 맞게 변경 필요.
+
         when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+        when(meetingRepository.save(any(Meeting.class)))
+                .thenAnswer(invocation -> {
+                    Meeting savedMeeting = invocation.getArgument(0);
+                    ReflectionTestUtils.setField(savedMeeting, "id", 10L);
+                    return savedMeeting;
+                });
 
         // when
-        meetingService.createMeeting(memberId, request);
+        MeetingCreateResponse response = meetingService.createMeeting(memberId, request);
 
         // then
-        verify(meetingRepository, times(1)).save(meeting);
-        ArgumentCaptor<MeetingParticipant> captor = ArgumentCaptor.forClass(MeetingParticipant.class);
-        verify(meetingParticipantRepository, times(1)).save(captor.capture());
+        // meeting 저장 검증
+        ArgumentCaptor<Meeting> meetingCaptor = ArgumentCaptor.forClass(Meeting.class);
+        verify(meetingRepository, times(1)).save(meetingCaptor.capture());
 
-        MeetingParticipant savedParticipant = captor.getValue();
-        assertThat(savedParticipant.getMeeting()).isSameAs(meeting);
-        assertThat(savedParticipant.getMember()).isSameAs(member);
+        Meeting savedMeeting = meetingCaptor.getValue();
+        assertThat(savedMeeting.getTitle()).isEqualTo("테스트 모임 생성");
+        assertThat(savedMeeting.getType()).isEqualTo(MeetingType.DRINKER);
+
+        // meetingParticipant 저장 검증
+        ArgumentCaptor<MeetingParticipant> meetingParticipantCaptor = ArgumentCaptor.forClass(MeetingParticipant.class);
+        verify(meetingParticipantRepository, times(1)).save(meetingParticipantCaptor.capture());
+
+        MeetingParticipant savedParticipant = meetingParticipantCaptor.getValue();
+        assertThat(savedParticipant.getMeeting().getTitle()).isEqualTo("테스트 모임 생성");
+        assertThat(savedParticipant.getMember()).isEqualTo(member);
         assertThat(savedParticipant.getRole()).isEqualTo(pyws.swyp.meeting.entity.ParticipantRole.HOST);
+
+        // 응답값 검증
+        assertThat(response.meetingId()).isEqualTo(10L);
     }
 
     @Test
@@ -324,9 +333,7 @@ public class MeetingServiceTest {
 
         Meeting meeting = Meeting.builder()
                 .title("모잇 오프라인 모임")
-                .date(null)
-                .dateVoteDeadline(LocalDateTime.of(2025,12,31,13,00))
-                .courseVoteDeadline(null)
+                .type(MeetingType.DRINKER)
                 .build();
 
         MeetingUpdateRequest request = new MeetingUpdateRequest(
@@ -351,8 +358,6 @@ public class MeetingServiceTest {
 
         assertThat(meeting.getTitle()).isEqualTo("모잇 오프라인 모임");
         assertThat(meeting.getDate()).isEqualTo(LocalDate.of(2026,1,20));
-        assertThat(meeting.getDateVoteDeadline()).isEqualTo(LocalDateTime.of(2025,12,31,13,00));
-        assertThat(meeting.getCourseVoteDeadline()).isNull();
     }
 
     @Test
@@ -364,9 +369,7 @@ public class MeetingServiceTest {
 
         Meeting meeting = Meeting.builder()
                 .title("모잇 오프라인 모임")
-                .date(null)
-                .dateVoteDeadline(LocalDateTime.of(2025,12,31,13,00))
-                .courseVoteDeadline(null)
+                .type(MeetingType.DRINKER)
                 .build();
 
         MeetingUpdateRequest request = new MeetingUpdateRequest(
@@ -393,8 +396,6 @@ public class MeetingServiceTest {
 
         assertThat(meeting.getTitle()).isEqualTo("모잇 오프라인 모임");
         assertThat(meeting.getDate()).isNull();
-        assertThat(meeting.getDateVoteDeadline()).isEqualTo(LocalDateTime.of(2025,12,31,13,00));
-        assertThat(meeting.getCourseVoteDeadline()).isNull();
     }
 
     @Test
@@ -406,9 +407,7 @@ public class MeetingServiceTest {
 
         Meeting meeting = Meeting.builder()
                 .title("모잇 오프라인 모임")
-                .date(null)
-                .dateVoteDeadline(LocalDateTime.of(2025,12,31,13,00))
-                .courseVoteDeadline(null)
+                .type(MeetingType.DRINKER)
                 .build();
 
         MeetingUpdateRequest request = new MeetingUpdateRequest(
@@ -437,8 +436,6 @@ public class MeetingServiceTest {
 
         assertThat(meeting.getTitle()).isEqualTo("모잇 오프라인 모임");
         assertThat(meeting.getDate()).isNull();
-        assertThat(meeting.getDateVoteDeadline()).isEqualTo(LocalDateTime.of(2025,12,31,13,00));
-        assertThat(meeting.getCourseVoteDeadline()).isNull();
 
     }
 

--- a/src/test/java/pyws/swyp/meeting/service/vote/DateVoteServiceTest.java
+++ b/src/test/java/pyws/swyp/meeting/service/vote/DateVoteServiceTest.java
@@ -16,10 +16,7 @@ import pyws.swyp.meeting.dto.vote.date.DateVoteRequest;
 import pyws.swyp.meeting.dto.vote.VoterResponse;
 import pyws.swyp.meeting.dto.vote.VotersResponse;
 import pyws.swyp.meeting.dto.vote.date.VotedDatesResponse;
-import pyws.swyp.meeting.entity.Meeting;
-import pyws.swyp.meeting.entity.MeetingParticipant;
-import pyws.swyp.meeting.entity.MeetingStatus;
-import pyws.swyp.meeting.entity.ParticipantRole;
+import pyws.swyp.meeting.entity.*;
 import pyws.swyp.meeting.entity.vote.DateVote;
 import pyws.swyp.meeting.repository.MeetingParticipantRepository;
 import pyws.swyp.meeting.repository.MeetingRepository;
@@ -60,6 +57,7 @@ class DateVoteServiceTest {
 
         Meeting meeting = Meeting.builder()
                 .title("테스트 모임")
+                .type(MeetingType.DRINKER)
                 .build();
         meeting.updateStatus(MeetingStatus.DATE_VOTING);
         this.meeting = meetingRepository.save(meeting);

--- a/src/test/java/pyws/swyp/meeting/service/vote/TimeVoteServiceTest.java
+++ b/src/test/java/pyws/swyp/meeting/service/vote/TimeVoteServiceTest.java
@@ -24,10 +24,7 @@ import pyws.swyp.meeting.dto.vote.time.VotedTimeResponse;
 import pyws.swyp.meeting.dto.vote.time.VotedTimesResponse;
 import pyws.swyp.meeting.dto.vote.VoterResponse;
 import pyws.swyp.meeting.dto.vote.VotersResponse;
-import pyws.swyp.meeting.entity.Meeting;
-import pyws.swyp.meeting.entity.MeetingParticipant;
-import pyws.swyp.meeting.entity.MeetingStatus;
-import pyws.swyp.meeting.entity.ParticipantRole;
+import pyws.swyp.meeting.entity.*;
 import pyws.swyp.meeting.entity.vote.TimeVote;
 import pyws.swyp.meeting.repository.MeetingParticipantRepository;
 import pyws.swyp.meeting.repository.MeetingRepository;
@@ -68,6 +65,7 @@ class TimeVoteServiceTest {
 
         Meeting meeting = Meeting.builder()
                 .title("테스트 모임")
+                .type(MeetingType.DRINKER)
                 .build();
         meeting.updateStatus(MeetingStatus.TIME_VOTING);
         this.meeting = meetingRepository.save(meeting);

--- a/src/test/java/pyws/swyp/meeting/service/vote/VoteSummaryServiceTest.java
+++ b/src/test/java/pyws/swyp/meeting/service/vote/VoteSummaryServiceTest.java
@@ -22,10 +22,7 @@ import pyws.swyp.meeting.dto.vote.date.DateSummary;
 import pyws.swyp.meeting.dto.vote.date.DateVoteRequest;
 import pyws.swyp.meeting.dto.vote.time.TimeSummary;
 import pyws.swyp.meeting.dto.vote.time.VotedTimeResponse;
-import pyws.swyp.meeting.entity.Meeting;
-import pyws.swyp.meeting.entity.MeetingParticipant;
-import pyws.swyp.meeting.entity.MeetingStatus;
-import pyws.swyp.meeting.entity.ParticipantRole;
+import pyws.swyp.meeting.entity.*;
 import pyws.swyp.meeting.entity.vote.DateVote;
 import pyws.swyp.meeting.entity.vote.TimeVote;
 import pyws.swyp.meeting.repository.MeetingParticipantRepository;
@@ -70,6 +67,7 @@ class VoteSummaryServiceTest {
         // meeting
         this.meeting = meetingRepository.save(Meeting.builder()
                 .title("테스트 모임")
+                .type(MeetingType.DRINKER)
                 .build());
 
         // member

--- a/src/test/java/pyws/swyp/member/service/MemberServiceTest.java
+++ b/src/test/java/pyws/swyp/member/service/MemberServiceTest.java
@@ -23,10 +23,7 @@ import org.springframework.transaction.support.TransactionTemplate;
 import pyws.swyp.auth.service.JwtService;
 import pyws.swyp.global.error.CustomException;
 import pyws.swyp.global.error.ErrorCode;
-import pyws.swyp.meeting.entity.Meeting;
-import pyws.swyp.meeting.entity.MeetingParticipant;
-import pyws.swyp.meeting.entity.MeetingStatus;
-import pyws.swyp.meeting.entity.ParticipantRole;
+import pyws.swyp.meeting.entity.*;
 import pyws.swyp.meeting.entity.vote.DateVote;
 import pyws.swyp.meeting.entity.vote.TimeVote;
 import pyws.swyp.meeting.repository.MeetingParticipantRepository;
@@ -121,6 +118,7 @@ class MemberServiceTest {
 
         meeting = Meeting.builder()
                 .title("테스트 모임")
+                .type(MeetingType.CULTURE_LOVER)
                 .build();
         meeting.updateStatus(MeetingStatus.DATE_VOTING);
         meetingRepository.save(meeting);
@@ -230,6 +228,7 @@ class MemberServiceTest {
         // given
         Meeting completed = Meeting.builder()
                 .title("완료된 모임")
+                .type(MeetingType.CULTURE_LOVER)
                 .build();
         completed.updateStatus(MeetingStatus.DONE);
         meetingRepository.save(completed);


### PR DESCRIPTION
### 📌 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- 기능 수정

### 📌 관련 이슈
#42 

### ✨ 반영 브랜치
refactor/42 -> develop

### 📝 변경 사항
- [x] meeting에 MeetingType enum 형식으로 추가
- [x]  request 기존 null 허용 상태였던 date, voteDeadLine 관련 삭제하고 Meetingtype 추가
- [x] response void -> meetingId, title 반환하도록 수정

### ➕ 추가 메모
- 저희 기획에서는 DateVoteDeadLine이랑 CourseVoteDeadLine 이 필요 없어진 것 같은데 Meeting에서 지워도 괜찮을까요?


### 🐛 테스트 결과 (테스트 결과가 있다면 넣어주세요)
<img width="827" height="378" alt="image" src="https://github.com/user-attachments/assets/5a127439-5cbd-45d9-9af3-148dda27288b" />

