### PR TITLE
feat: #41 소셜 로그인 연결 해제 콜백 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 ### Custom ###
 src/main/**/application-local.yml
+src/main/resources/firebase/serviceAccount.json
 
 ### Basic ###
 HELP.md

--- a/src/main/java/pyws/swyp/auth/controller/AuthController.java
+++ b/src/main/java/pyws/swyp/auth/controller/AuthController.java
@@ -1,11 +1,14 @@
 package pyws.swyp.auth.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import pyws.swyp.auth.controller.api.AuthApi;
 import pyws.swyp.auth.dto.AuthResponse;
@@ -42,5 +45,27 @@ public class AuthController implements AuthApi {
     @PostMapping("/reissue")
     public JwtResponse reissue(@RequestBody @Validated ReissueRequest request) {
         return jwtService.reissue(request.refreshToken());
+    }
+
+    @PostMapping("/oauth/kakao/unlink")
+    public ResponseEntity<Void> handleKakaoUnlinkCallback(
+            @RequestHeader("Authorization") String authorization,
+            @RequestParam("app_id") String appId,
+            @RequestParam("user_id") String userId,
+            @RequestParam(value = "referrer_type") String referrerType
+    ) {
+        authService.handleKakaoUnlinkCallback(authorization, appId, userId, referrerType);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/oauth/naver/unlink")
+    public ResponseEntity<Void> handleNaverUnlinkCallback(
+            @RequestParam("clientId") String clientId,
+            @RequestParam("encryptUniqueId") String encryptUniqueId,
+            @RequestParam("timestamp") String timestamp,
+            @RequestParam("signature") String signature
+    ) {
+        authService.handleNaverUnlinkCallback(clientId, encryptUniqueId, timestamp, signature);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/pyws/swyp/auth/controller/AuthController.java
+++ b/src/main/java/pyws/swyp/auth/controller/AuthController.java
@@ -52,7 +52,7 @@ public class AuthController implements AuthApi {
             @RequestHeader("Authorization") String authorization,
             @RequestParam("app_id") String appId,
             @RequestParam("user_id") String userId,
-            @RequestParam(value = "referrer_type") String referrerType
+            @RequestParam("referrer_type") String referrerType
     ) {
         authService.handleKakaoUnlinkCallback(authorization, appId, userId, referrerType);
         return ResponseEntity.ok().build();

--- a/src/main/java/pyws/swyp/auth/controller/api/AuthApi.java
+++ b/src/main/java/pyws/swyp/auth/controller/api/AuthApi.java
@@ -8,8 +8,12 @@ import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
 import pyws.swyp.auth.dto.AuthResponse;
 import pyws.swyp.auth.dto.JwtResponse;
 import pyws.swyp.auth.dto.LoginRequest;
@@ -206,4 +210,114 @@ public interface AuthApi {
             )
     )
     JwtResponse reissue(@RequestBody @Validated ReissueRequest request);
+
+    @Operation(
+            summary = "카카오 연결 해제 콜백",
+            description =
+                    """
+                    카카오 서버가 사용자의 서비스 연결 해제 이벤트 발생 시 호출하는 콜백 API입니다.
+    
+                    - 호출 주체: 카카오 서버
+                    - 인증 방식: Authorization 헤더 (KakaoAK {PRIMARY_ADMIN_KEY})
+                    - 정상 처리 시 HTTP 200(OK) 반환
+    
+                    referrer_type 값:
+                    - ACCOUNT_DELETE: 카카오 계정 탈퇴
+                    - FORCED_ACCOUNT_DELETE: 장기 휴면 또는 고객센터에 의한 강제 탈퇴
+                    - UNLINK_FROM_ADMIN: 카카오 관리자에 의한 탈퇴
+                    - UNLINK_FROM_APPS: 카카오 계정 페이지에서 서비스 연결 해제
+                    - INCOMPLETE_SIGN_UP: 가입 미완료 사용자 연결 해제
+                    """
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "카카오 연결 해제 콜백 처리 성공"
+    )
+    @PostMapping("/oauth/kakao/unlink")
+    ResponseEntity<Void> handleKakaoUnlinkCallback(
+            @Parameter(
+                    name = "Authorization",
+                    description = "카카오 어드민 키 (형식: KakaoAK {PRIMARY_ADMIN_KEY})",
+                    required = true,
+                    example = "KakaoAK a1b2c3d4e5"
+            )
+            @RequestHeader("Authorization") String authorization,
+
+            @Parameter(
+                    name = "app_id",
+                    description = "연결 해제 요청이 발생한 카카오 앱 ID",
+                    required = true,
+                    example = "123456789"
+            )
+            @RequestParam("app_id") String appId,
+
+            @Parameter(
+                    name = "user_id",
+                    description = "카카오 회원 번호 (user_id)",
+                    required = true,
+                    example = "987654321"
+            )
+            @RequestParam("user_id") String userId,
+
+            @Parameter(
+                    name = "referrer_type",
+                    description = "연결 해제 요청 경로",
+                    required = true,
+                    example = "UNLINK_FROM_APPS"
+            )
+            @RequestParam("referrer_type") String referrerType
+    );
+
+    @Operation(
+            summary = "네이버 연결 해제 알림 콜백",
+            description =
+                    """
+                    네이버 서버가 사용자의 서비스 연결 해제 이벤트 발생 시 호출하는 콜백 API입니다.
+    
+                    - 호출 주체: 네이버 서버
+                    - 인증 방식: 요청 파라미터 기반 무결성 검증
+                    - 정상 처리 시 HTTP 204(No Content) 반환
+    
+                    검증 요소:
+                    - clientId
+                    - encryptUniqueId (AES128/CBC 암호화)
+                    - timestamp (Unix epoch second)
+                    - signature (HMAC 서명)
+                    """
+    )
+    @ApiResponse(
+            responseCode = "204",
+            description = "네이버 연결 해제 콜백 처리 성공"
+    )
+    @PostMapping("/oauth/naver/unlink")
+    ResponseEntity<Void> handleNaverUnlinkCallback(
+            @Parameter(
+                    description = "네이버 애플리케이션 Client ID",
+                    required = true,
+                    example = "naver-client-id"
+            )
+            @RequestParam("clientId") String clientId,
+
+            @Parameter(
+                    description = "암호화된 네이버 이용자 고유 식별자",
+                    required = true,
+                    example = "hjDkQ1h_FNFiklPyEKBZwbwE"
+            )
+            @RequestParam("encryptUniqueId") String encryptUniqueId,
+
+            @Parameter(
+                    description = "요청 시점의 Unix epoch time (second)",
+                    required = true,
+                    example = "1693877406"
+            )
+            @RequestParam("timestamp") String timestamp,
+
+            @Parameter(
+                    description = "요청 무결성 검증을 위한 HMAC 서명 값",
+                    required = true,
+                    example = "XUGURE_KaNSs-Y0"
+            )
+            @RequestParam("signature") String signature
+    );
+
 }

--- a/src/main/java/pyws/swyp/auth/oauth/NaverUnlinkCrypto.java
+++ b/src/main/java/pyws/swyp/auth/oauth/NaverUnlinkCrypto.java
@@ -1,0 +1,150 @@
+package pyws.swyp.auth.oauth;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.Arrays;
+import java.util.Base64;
+import javax.crypto.Cipher;
+import javax.crypto.Mac;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+
+/**
+ * 네이버 로그인 연결 끊기(unlink) 콜백 검증을 위한 암호화/서명 유틸리티
+ *
+ * <pre>
+ * - AES128 / CBC / PKCS5Padding : encryptUniqueId 복호화
+ * - HmacSHA256(HS256)           : 요청 위변조 방지 서명 검증
+ *
+ * 1. clientSecret → MD5 → 앞 16byte → AES/HMAC 공통 키 생성
+ * 2. encryptUniqueId 복호화
+ *    - base64url 디코딩
+ *    - 앞 16byte = IV
+ *    - 나머지 = AES128-CBC 암호문
+ * 3. HMAC 서명 검증
+ *    - "clientId=...&encryptUniqueId=...&timestamp=..." 문자열로 서명 생성
+ * </pre>
+ */
+public class NaverUnlinkCrypto {
+
+    private static final String ALGORITHM_AES_CBC_PKCS5 = "AES/CBC/PKCS5Padding";
+    private static final String ALGORITHM_AES = "AES";
+    private static final String ALGORITHM_HS256 = "HmacSHA256";
+    private static final int BLOCK_SIZE = 16;
+
+    /**
+     * 네이버 규격에 따른 암호화/서명 공통 키 생성
+     *
+     * <pre>
+     * encryptKey (16byte) = md5(clientSecret)[0..15]
+     *
+     * - AES128-CBC encryptUniqueId 복호화 키
+     * - HmacSHA256(HS256) 서명 검증 키
+     *
+     * ※ 네이버 규격상 AES와 HMAC 모두 동일한 키를 사용한다.
+     * </pre>
+     *
+     * @param clientSecret 네이버에서 발급받은 Client Secret
+     * @return 16바이트 AES/HMAC 공통 키
+     */
+    public static byte[] generateKey(String clientSecret) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("MD5");
+            md.update(clientSecret.getBytes(StandardCharsets.UTF_8));
+            return Arrays.copyOfRange(md.digest(), 0, BLOCK_SIZE);
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to generate MD5 key", e);
+        }
+    }
+
+    /**
+     * encryptUniqueId 복호화
+     *
+     * <pre>
+     * encryptUniqueId = base64url( IV(16byte) + AES128-CBC(cipherText) )
+     *
+     * 1. base64url 디코딩
+     * 2. 앞 16byte → IV
+     * 3. 나머지 → 암호문
+     * 4. AES128 / CBC / PKCS5Padding 방식으로 복호화
+     * </pre>
+     *
+     * @param encrypted 네이버에서 전달한 암호화된 uniqueId
+     * @param key       generateKey()로 생성한 16byte 키
+     * @return 복호화된 네이버 사용자 uniqueId
+     */
+    public static String decryptUniqueId(String encrypted, byte[] key) {
+        try {
+            byte[] encryptedWithIv = Base64.getUrlDecoder().decode(encrypted);
+            byte[] iv = Arrays.copyOfRange(encryptedWithIv, 0, BLOCK_SIZE);
+            byte[] encryptedUniqueId = Arrays.copyOfRange(encryptedWithIv, BLOCK_SIZE, encryptedWithIv.length);
+
+            SecretKeySpec skeySpec = new SecretKeySpec(key, ALGORITHM_AES);
+            Cipher cipher = Cipher.getInstance(ALGORITHM_AES_CBC_PKCS5);
+            IvParameterSpec ivspec = new IvParameterSpec(iv);
+
+            cipher.init(Cipher.DECRYPT_MODE, skeySpec, ivspec);
+
+            byte[] decrypted = cipher.doFinal(encryptedUniqueId);
+            return new String(decrypted, StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Failed to decrypt encryptUniqueId", e);
+        }
+    }
+
+    /**
+     * HMAC 서명 생성 (요청 위변조 검증용)
+     *
+     * <pre>
+     * signature = base64url(
+     *   HmacSHA256("clientId=...&encryptUniqueId=...&timestamp=...", key)
+     * )
+     * </pre>
+     */
+    public static String generateMac(String signatureBaseString, byte[] key) {
+        try {
+            SecretKeySpec secretKey = new SecretKeySpec(key, ALGORITHM_HS256);
+            Mac mac = Mac.getInstance(ALGORITHM_HS256);
+            mac.init(secretKey);
+
+            byte[] hash = mac.doFinal(signatureBaseString.getBytes(StandardCharsets.UTF_8));
+            return Base64.getUrlEncoder().withoutPadding().encodeToString(hash);
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to generate HMAC", e);
+        }
+    }
+
+    /**
+     * HMAC 서명 원문 생성
+     *
+     * <pre>
+     * clientId={clientId}&encryptUniqueId={encryptUniqueId}&timestamp={timestamp}
+     * </pre>
+     */
+    public static String signatureBaseString(String clientId, String encryptUniqueId, String timestamp) {
+        String baseStringFmt = "clientId=%s&encryptUniqueId=%s&timestamp=%s";
+        return String.format(baseStringFmt, clientId, encryptUniqueId, timestamp);
+    }
+
+    /**
+     * 타이밍 공격 방지용 상수시간 비교 -> 모든 문자 비교
+     */
+    public static boolean constantTimeEquals(String a, String b) {
+        if (a == null || b == null) {
+            return false;
+        }
+        byte[] x = a.getBytes(StandardCharsets.UTF_8);
+        byte[] y = b.getBytes(StandardCharsets.UTF_8);
+        if (x.length != y.length) {
+            return false;
+        }
+
+        // 한 번이라도 다르면 r은 0이 될 수 없음
+        int r = 0;
+        for (int i = 0; i < x.length; i++) {
+            r |= (x[i] ^ y[i]);
+        }
+        return r == 0;
+    }
+}
+

--- a/src/main/java/pyws/swyp/auth/oauth/OAuthProperties.java
+++ b/src/main/java/pyws/swyp/auth/oauth/OAuthProperties.java
@@ -1,0 +1,12 @@
+package pyws.swyp.auth.oauth;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "oauth")
+public record OAuthProperties(
+        Kakao kakao,
+        Naver naver
+) {
+    public record Kakao(String appId, String adminKey) {}
+    public record Naver(String clientId,String clientSecret) {}
+}

--- a/src/main/java/pyws/swyp/auth/service/AuthService.java
+++ b/src/main/java/pyws/swyp/auth/service/AuthService.java
@@ -4,18 +4,24 @@ import static pyws.swyp.global.error.ErrorCode.SOCIAL_ACCOUNT_ALREADY_EXISTS;
 
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import pyws.swyp.auth.dto.AuthResponse;
 import pyws.swyp.auth.dto.JwtResponse;
 import pyws.swyp.auth.dto.LoginRequest;
 import pyws.swyp.auth.dto.SignupRequest;
+import pyws.swyp.auth.oauth.NaverUnlinkCrypto;
+import pyws.swyp.auth.oauth.OAuthProperties;
 import pyws.swyp.member.entity.Member;
 import pyws.swyp.member.entity.MemberRole;
 import pyws.swyp.member.entity.SocialAccount;
+import pyws.swyp.member.entity.SocialProvider;
 import pyws.swyp.member.repository.MemberRepository;
 import pyws.swyp.member.repository.SocialAccountRepository;
+import pyws.swyp.member.service.MemberService;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class AuthService {
@@ -23,6 +29,8 @@ public class AuthService {
     private final MemberRepository memberRepository;
     private final SocialAccountRepository socialAccountRepository;
     private final JwtService jwtService;
+    private final OAuthProperties oAuthProperties;
+    private final MemberService memberService;
 
     @Transactional(readOnly = true)
     public AuthResponse login(LoginRequest request) {
@@ -85,5 +93,80 @@ public class AuthService {
 
     public void logout(Long memberId) {
         jwtService.logout(memberId);
+    }
+
+    @Transactional
+    public void handleKakaoUnlinkCallback(String authorization, String appId, String userId, String referrerType) {
+        // Authorization 헤더 검증
+        String expectedAuth = "KakaoAK " + oAuthProperties.kakao().adminKey();
+        if (!expectedAuth.equals(authorization)) {
+            log.warn("Invalid Kakao Authorization header.");
+            return;
+        }
+
+        // appId 검증
+        if (!oAuthProperties.kakao().appId().equals(appId)) {
+            log.warn("Invalid Kakao appId. received={}", appId);
+            return;
+        }
+
+        SocialAccount socialAccount = socialAccountRepository
+                .findBySocialProviderAndSocialId(SocialProvider.KAKAO, userId)
+                .orElse(null);
+
+        if (socialAccount == null) {
+            log.warn("SocialAccount not found.");
+            return;
+        }
+
+        processUnlink(socialAccount);
+    }
+
+    @Transactional
+    public void handleNaverUnlinkCallback(String clientId, String encryptUniqueId, String timestamp, String signature) {
+        // clientId 검증
+        if (!oAuthProperties.naver().clientId().equals(clientId)) {
+            log.warn("Invalid Naver clientId. received={}", clientId);
+            return;
+        }
+
+        // HMAC 검증
+        byte[] key = NaverUnlinkCrypto.generateKey(oAuthProperties.naver().clientSecret());
+        String baseString = NaverUnlinkCrypto.signatureBaseString(clientId, encryptUniqueId, timestamp);
+        String generated = NaverUnlinkCrypto.generateMac(baseString, key);
+
+        if (!NaverUnlinkCrypto.constantTimeEquals(generated, signature)) {
+            log.warn("Invalid Naver unlink signature.");
+            return;
+        }
+
+        // encryptUniqueId 복호화
+        String uniqueId = NaverUnlinkCrypto.decryptUniqueId(encryptUniqueId, key);
+
+        // DB 소셜 계정 조회
+        SocialAccount socialAccount = socialAccountRepository
+                .findBySocialProviderAndSocialId(SocialProvider.NAVER, uniqueId)
+                .orElse(null);
+
+        if (socialAccount == null) {
+            log.warn("SocialAccount not found.");
+            return;
+        }
+
+        processUnlink(socialAccount);
+    }
+
+    private void processUnlink(SocialAccount socialAccount) {
+        Long memberId = socialAccount.getMember().getId();
+        long linkedCount = socialAccountRepository.countByMemberId(memberId);
+
+        // 소셜 계정이 2개 이상일 경우 연동된 소셜 계정만 제거
+        if (linkedCount >= 2) {
+            socialAccountRepository.delete(socialAccount);
+            return;
+        }
+
+        // 유일한 소셜 계정일 경우 회원 탈퇴
+        memberService.withdrawByUnlinkCallback(memberId);
     }
 }

--- a/src/main/java/pyws/swyp/global/security/SecurityConfig.java
+++ b/src/main/java/pyws/swyp/global/security/SecurityConfig.java
@@ -39,7 +39,8 @@ public class SecurityConfig {
                                 "/v3/api-docs/**",
                                 "/api/auth/login",
                                 "/api/auth/signup",
-                                "/api/auth/reissue"
+                                "/api/auth/reissue",
+                                "/api/auth/oauth/**"
                         ).permitAll()
                         .requestMatchers(CorsUtils::isPreFlightRequest).permitAll()
                         .anyRequest().authenticated())

--- a/src/main/java/pyws/swyp/member/entity/WithdrawalType.java
+++ b/src/main/java/pyws/swyp/member/entity/WithdrawalType.java
@@ -4,5 +4,6 @@ public enum WithdrawalType {
     SCHEDULE_INCONVENIENT,   // 일정 생성이 불편해요
     NO_FEATURE,              // 원하는 기능이 없어요
     BUG,                     // 버그가 자꾸 발생해요
+    SOCIAL_UNLINK,           // 소셜 연동 해제
     ETC                      // 기타
 }

--- a/src/main/java/pyws/swyp/member/repository/SocialAccountRepository.java
+++ b/src/main/java/pyws/swyp/member/repository/SocialAccountRepository.java
@@ -20,4 +20,6 @@ public interface SocialAccountRepository extends JpaRepository<SocialAccount, Lo
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("delete from SocialAccount sa where sa.member.id = :memberId")
     int deleteAllByMemberId(Long memberId);
+
+    long countByMemberId(Long memberId);
 }

--- a/src/main/java/pyws/swyp/member/service/MemberService.java
+++ b/src/main/java/pyws/swyp/member/service/MemberService.java
@@ -15,6 +15,7 @@ import pyws.swyp.member.dto.SocialAccountInfo;
 import pyws.swyp.member.entity.CharacterType;
 import pyws.swyp.member.entity.Member;
 import pyws.swyp.member.entity.MemberWithdrawal;
+import pyws.swyp.member.entity.WithdrawalType;
 import pyws.swyp.member.repository.MemberRepository;
 import pyws.swyp.member.repository.MemberWithdrawalRepository;
 import pyws.swyp.member.repository.SocialAccountRepository;
@@ -78,6 +79,22 @@ public class MemberService {
         jwtService.logout(memberId);
 
         // 회원 삭제
+        memberRepository.delete(member);
+    }
+
+    @Transactional
+    public void withdrawByUnlinkCallback(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(MEMBER_NOT_FOUND::toException);
+
+        MemberWithdrawal memberWithdrawal = MemberWithdrawal.builder()
+                .type(WithdrawalType.SOCIAL_UNLINK)
+                .build();
+        memberWithdrawalRepository.save(memberWithdrawal);
+
+        socialAccountRepository.deleteAllByMemberId(memberId);
+        memberWithdrawCleanupService.cleanup(memberId);
+        jwtService.logout(memberId);
         memberRepository.delete(member);
     }
 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -39,3 +39,11 @@ springdoc:
 firebase:
   credentials:
     location: ${FIREBASE_CREDENTIAL_LOCATION}
+
+oauth:
+  kakao:
+    app-id: ${KAKAO_APP_ID}
+    admin-key: ${KAKAO_ADMIN_KEY}
+  naver:
+    client-id: ${NAVER_CLIENT_ID}
+    client-secret: ${NAVER_CLIENT_SECRET}

--- a/src/test/java/pyws/swyp/auth/controller/AuthWebhookControllerTest.java
+++ b/src/test/java/pyws/swyp/auth/controller/AuthWebhookControllerTest.java
@@ -1,0 +1,64 @@
+package pyws.swyp.auth.controller;
+
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.test.context.TestConstructor;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import pyws.swyp.auth.service.AuthService;
+import pyws.swyp.auth.service.JwtService;
+import pyws.swyp.global.jwt.JwtProvider;
+
+@WebMvcTest(AuthController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class AuthWebhookControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockitoBean
+    AuthService authService;
+
+    @MockitoBean
+    JwtService jwtService;
+
+    @MockitoBean
+    JwtProvider jwtProvider;
+
+    @Test
+    @DisplayName("카카오 unlink 콜백 - 정상 요청이면 200 OK")
+    void kakaoUnlink_ok() throws Exception {
+        mockMvc.perform(post("/api/auth/oauth/kakao/unlink")
+                        .header("Authorization", "KakaoAK test-admin-key")
+                        .param("app_id", "123")
+                        .param("user_id", "456")
+                        .param("referrer_type", "UNLINK_FROM_APPS"))
+                .andExpect(status().isOk());
+
+        verify(authService).handleKakaoUnlinkCallback(
+                "KakaoAK test-admin-key", "123", "456", "UNLINK_FROM_APPS"
+        );
+    }
+
+    @Test
+    @DisplayName("네이버 unlink 콜백 - 정상 요청이면 204 No Content")
+    void naverUnlink_noContent() throws Exception {
+        mockMvc.perform(post("/api/auth/oauth/naver/unlink")
+                        .param("clientId", "naver-client-id")
+                        .param("encryptUniqueId", "encrypted")
+                        .param("timestamp", "1693877406")
+                        .param("signature", "signature"))
+                .andExpect(status().isNoContent());
+
+        verify(authService).handleNaverUnlinkCallback(
+                "naver-client-id", "encrypted", "1693877406", "signature"
+        );
+    }
+}

--- a/src/test/java/pyws/swyp/auth/service/AuthServiceNaverUnlinkTest.java
+++ b/src/test/java/pyws/swyp/auth/service/AuthServiceNaverUnlinkTest.java
@@ -1,0 +1,211 @@
+package pyws.swyp.auth.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import pyws.swyp.auth.oauth.NaverUnlinkCrypto;
+import pyws.swyp.auth.oauth.OAuthProperties;
+import pyws.swyp.member.entity.Member;
+import pyws.swyp.member.entity.SocialAccount;
+import pyws.swyp.member.entity.SocialProvider;
+import pyws.swyp.member.repository.SocialAccountRepository;
+import pyws.swyp.member.service.MemberService;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceNaverUnlinkTest {
+
+    @Mock
+    OAuthProperties oAuthProperties;
+    @Mock
+    OAuthProperties.Naver naverProps;
+    @Mock
+    SocialAccountRepository socialAccountRepository;
+    @Mock
+    MemberService memberService;
+
+    @InjectMocks
+    AuthService authService;
+
+    @Test
+    @DisplayName("clientId가 다르면 바로 return, crypto/DB/withdraw/delete 호출 없음")
+    void invalidClientId_returnsEarly() {
+        // given
+        given(oAuthProperties.naver()).willReturn(naverProps);
+        given(naverProps.clientId()).willReturn("expected-client");
+
+        // when
+        authService.handleNaverUnlinkCallback("wrong-client", "enc", "ts", "sig");
+
+        // then
+        verifyNoInteractions(socialAccountRepository);
+        verifyNoInteractions(memberService);
+    }
+
+    @Test
+    @DisplayName("signature가 다르면 return, decrypt/DB/withdraw/delete 호출 없음")
+    void invalidSignature_returnsEarly() {
+        // given
+        String clientId = "client";
+        String encryptUniqueId = "enc";
+        String timestamp = "1693877406";
+        String signature = "received-sig";
+
+        given(oAuthProperties.naver()).willReturn(naverProps);
+        given(naverProps.clientId()).willReturn(clientId);
+        given(naverProps.clientSecret()).willReturn("secret");
+
+        try (MockedStatic<NaverUnlinkCrypto> crypto = Mockito.mockStatic(NaverUnlinkCrypto.class)) {
+            byte[] key = new byte[]{1, 2, 3};
+
+            crypto.when(() -> NaverUnlinkCrypto.generateKey("secret")).thenReturn(key);
+            crypto.when(() -> NaverUnlinkCrypto.signatureBaseString(clientId, encryptUniqueId, timestamp))
+                    .thenReturn("base");
+            crypto.when(() -> NaverUnlinkCrypto.generateMac("base", key))
+                    .thenReturn("generated-sig");
+            crypto.when(() -> NaverUnlinkCrypto.constantTimeEquals("generated-sig", signature))
+                    .thenReturn(false);
+
+            // when
+            authService.handleNaverUnlinkCallback(clientId, encryptUniqueId, timestamp, signature);
+
+            // then
+            crypto.verify(() -> NaverUnlinkCrypto.decryptUniqueId(anyString(), any()), never());
+            verifyNoInteractions(socialAccountRepository);
+            verifyNoInteractions(memberService);
+        }
+    }
+
+    @Test
+    @DisplayName("복호화 성공했지만 SocialAccount 없으면 return, withdraw/delete 호출 없음")
+    void socialAccountNotFound_returnsEarly() {
+        // given
+        String clientId = "client";
+        String encryptUniqueId = "enc";
+        String timestamp = "1693877406";
+        String signature = "sig";
+
+        given(oAuthProperties.naver()).willReturn(naverProps);
+        given(naverProps.clientId()).willReturn(clientId);
+        given(naverProps.clientSecret()).willReturn("secret");
+
+        try (MockedStatic<NaverUnlinkCrypto> crypto = Mockito.mockStatic(NaverUnlinkCrypto.class)) {
+            byte[] key = new byte[]{1, 2, 3};
+
+            crypto.when(() -> NaverUnlinkCrypto.generateKey("secret")).thenReturn(key);
+            crypto.when(() -> NaverUnlinkCrypto.signatureBaseString(clientId, encryptUniqueId, timestamp))
+                    .thenReturn("base");
+            crypto.when(() -> NaverUnlinkCrypto.generateMac("base", key)).thenReturn("generated");
+            crypto.when(() -> NaverUnlinkCrypto.constantTimeEquals("generated", signature)).thenReturn(true);
+            crypto.when(() -> NaverUnlinkCrypto.decryptUniqueId(encryptUniqueId, key)).thenReturn("unique-id");
+
+            given(socialAccountRepository.findBySocialProviderAndSocialId(SocialProvider.NAVER, "unique-id"))
+                    .willReturn(Optional.empty());
+
+            // when
+            authService.handleNaverUnlinkCallback(clientId, encryptUniqueId, timestamp, signature);
+
+            // then
+            verifyNoInteractions(memberService);
+            verify(socialAccountRepository, never()).delete(any());
+        }
+    }
+
+    @Test
+    @DisplayName("모든 검증 통과 + linkedCount>=2면 SocialAccount만 삭제한다")
+    void success_whenMultipleLinkedAccounts_deletesSocialAccountOnly() {
+        // given
+        String clientId = "client";
+        String encryptUniqueId = "enc";
+        String timestamp = "1693877406";
+        String signature = "sig";
+
+        Member member = mock(Member.class);
+        given(member.getId()).willReturn(10L);
+
+        SocialAccount socialAccount = mock(SocialAccount.class);
+        given(socialAccount.getMember()).willReturn(member);
+
+        given(oAuthProperties.naver()).willReturn(naverProps);
+        given(naverProps.clientId()).willReturn(clientId);
+        given(naverProps.clientSecret()).willReturn("secret");
+
+        try (MockedStatic<NaverUnlinkCrypto> crypto = Mockito.mockStatic(NaverUnlinkCrypto.class)) {
+            byte[] key = new byte[]{1, 2, 3};
+
+            crypto.when(() -> NaverUnlinkCrypto.generateKey("secret")).thenReturn(key);
+            crypto.when(() -> NaverUnlinkCrypto.signatureBaseString(clientId, encryptUniqueId, timestamp))
+                    .thenReturn("base");
+            crypto.when(() -> NaverUnlinkCrypto.generateMac("base", key)).thenReturn("generated");
+            crypto.when(() -> NaverUnlinkCrypto.constantTimeEquals("generated", signature)).thenReturn(true);
+            crypto.when(() -> NaverUnlinkCrypto.decryptUniqueId(encryptUniqueId, key)).thenReturn("unique-id");
+
+            given(socialAccountRepository.findBySocialProviderAndSocialId(SocialProvider.NAVER, "unique-id"))
+                    .willReturn(Optional.of(socialAccount));
+            given(socialAccountRepository.countByMemberId(10L)).willReturn(2L);
+
+            // when
+            authService.handleNaverUnlinkCallback(clientId, encryptUniqueId, timestamp, signature);
+
+            // then
+            verify(socialAccountRepository).delete(socialAccount);
+            verify(memberService, never()).withdrawByUnlinkCallback(anyLong());
+        }
+    }
+
+    @Test
+    @DisplayName("모든 검증 통과 + linkedCount==1이면 회원 탈퇴")
+    void success_whenSingleLinkedAccount_withdrawsMember() {
+        // given
+        String clientId = "client";
+        String encryptUniqueId = "enc";
+        String timestamp = "1693877406";
+        String signature = "sig";
+
+        Member member = mock(Member.class);
+        given(member.getId()).willReturn(10L);
+
+        SocialAccount socialAccount = mock(SocialAccount.class);
+        given(socialAccount.getMember()).willReturn(member);
+
+        given(oAuthProperties.naver()).willReturn(naverProps);
+        given(naverProps.clientId()).willReturn(clientId);
+        given(naverProps.clientSecret()).willReturn("secret");
+
+        try (MockedStatic<NaverUnlinkCrypto> crypto = Mockito.mockStatic(NaverUnlinkCrypto.class)) {
+            byte[] key = new byte[]{1, 2, 3};
+
+            crypto.when(() -> NaverUnlinkCrypto.generateKey("secret")).thenReturn(key);
+            crypto.when(() -> NaverUnlinkCrypto.signatureBaseString(clientId, encryptUniqueId, timestamp))
+                    .thenReturn("base");
+            crypto.when(() -> NaverUnlinkCrypto.generateMac("base", key)).thenReturn("generated");
+            crypto.when(() -> NaverUnlinkCrypto.constantTimeEquals("generated", signature)).thenReturn(true);
+            crypto.when(() -> NaverUnlinkCrypto.decryptUniqueId(encryptUniqueId, key)).thenReturn("unique-id");
+
+            given(socialAccountRepository.findBySocialProviderAndSocialId(SocialProvider.NAVER, "unique-id"))
+                    .willReturn(Optional.of(socialAccount));
+            given(socialAccountRepository.countByMemberId(10L)).willReturn(1L);
+
+            // when
+            authService.handleNaverUnlinkCallback(clientId, encryptUniqueId, timestamp, signature);
+
+            // then
+            verify(memberService).withdrawByUnlinkCallback(10L);
+            verify(socialAccountRepository, never()).delete(any());
+        }
+    }
+}


### PR DESCRIPTION
### 📌 PR 타입
- 기능 추가

### 📌 관련 이슈
#41 

### ✨ 반영 브랜치
feat/41 -> develop

### 📝 변경 사항
- [x] 카카오 / 네이버 소셜 로그인 연결 해제 콜백 API 추가

### 🐛 테스트 결과 
<img width="494" height="245" alt="image" src="https://github.com/user-attachments/assets/34ff9849-d36d-439e-9212-a345381720a1" />

