### PR TITLE
refactor: #48 VoteSummary 응답 구조 수정 및 MeetingStatus enum 수정

### DIFF
--- a/src/main/java/pyws/swyp/global/error/ErrorCode.java
+++ b/src/main/java/pyws/swyp/global/error/ErrorCode.java
@@ -46,7 +46,7 @@ public enum ErrorCode {
     MEETING_NOT_FOUND_IN_MONTH(NOT_FOUND, "MEET0012", "해당 월에 모임이 존재하지 않습니다."),
     MEETING_DATE_NOT_CONFIRMED(BAD_REQUEST, "MEET0013", "확정된 모임 날짜가 없습니다."),
     MEETING_TIME_NOT_CONFIRMED(BAD_REQUEST, "MEET0014", "확정된 모임 시간이 없습니다."),
-    MEETING_NOT_TIME_CANCELABLE(BAD_REQUEST, "MEET0015", "날짜가 확정된 모임만 시간 확정을 취소할 수 있습니다."),
+    MEETING_NOT_TIME_CANCELABLE(BAD_REQUEST, "MEET0015", "이미 완료된 모임은 시간 확정을 취소할 수 있습니다."),
 
     // Vote
     DATE_VOTE_NOT_FOUND(NOT_FOUND, "VOTE0001", "아직 시간 투표가 존재하지 않습니다."),

--- a/src/main/java/pyws/swyp/meeting/controller/api/MeetingApi.java
+++ b/src/main/java/pyws/swyp/meeting/controller/api/MeetingApi.java
@@ -164,7 +164,7 @@ public interface MeetingApi {
             description =
                     """
                             "친구들이 기다려요" -> 더보기 클릭 시 요청한 모임 리스트 조회를 처리합니다.
-                            Meeting.Status의 값이 CREATED, DATE_VOTING, PLACE_VOTING인 경우만 반환합니다.
+                            Meeting.Status의 값이 IN_PROGRESS인 경우만 반환합니다.
                     """
     )
     @ApiResponse(

--- a/src/main/java/pyws/swyp/meeting/controller/api/MeetingRecordApi.java
+++ b/src/main/java/pyws/swyp/meeting/controller/api/MeetingRecordApi.java
@@ -20,7 +20,7 @@ import pyws.swyp.meeting.dto.MeetingRecordResponse;
 
 @RequestMapping("/api/meetings/{meetingId}/records")
 @SecurityRequirement(name = "auth")
-@Tag(name = "Meeting Review API", description = "모임 후기 작성 및 조회 API")
+@Tag(name = "Meeting Record API", description = "모임 후기 작성 및 조회 API")
 public interface MeetingRecordApi {
 
     @Operation(

--- a/src/main/java/pyws/swyp/meeting/controller/api/vote/DateVoteApi.java
+++ b/src/main/java/pyws/swyp/meeting/controller/api/vote/DateVoteApi.java
@@ -31,7 +31,6 @@ public interface DateVoteApi {
                             
                             - 요청으로 전달된 날짜 목록으로 투표가 저장됩니다. (중복 날짜는 제거됩니다.)
                             - 기존에 내가 투표했던 날짜는 모두 삭제되고, 새 목록으로 다시 저장됩니다. (replace 방식)
-                            - 모임 상태가 CREATED인 경우 DATE_VOTING으로 변경될 수 있습니다.
                             
                             Authorization 헤더에 Access Token이 필요합니다.
                             """

--- a/src/main/java/pyws/swyp/meeting/controller/api/vote/VoteSummaryApi.java
+++ b/src/main/java/pyws/swyp/meeting/controller/api/vote/VoteSummaryApi.java
@@ -25,7 +25,6 @@ public interface VoteSummaryApi {
                     특정 모임의 전체 투표 현황을 요약 조회합니다.
                     
                     조회 정보:
-                    - 모임 상태 (meetingStatus: VOTING / FIXED(일자 확정) / DONE(지난 모임))
                     - 호스트 여부 (isHost)
                     - 확정된 날짜 / 시간
                     - 날짜 투표 요약
@@ -34,6 +33,7 @@ public interface VoteSummaryApi {
                     - 시간 투표 요약
                       - Top N 시간
                       - 시간별 투표 수 목록
+                      - 나의 투표 목록
                     
                     Authorization 헤더에 Access Token이 필요합니다.
                     """
@@ -52,7 +52,6 @@ public interface VoteSummaryApi {
                                               "code": "SUCCESS",
                                               "message": "요청이 성공적으로 처리되었습니다.",
                                               "data": {
-                                                "meetingStatus": "VOTING",
                                                 "isHost": true,
                                                 "confirmedDate": null,
                                                 "confirmedTime": null,
@@ -90,6 +89,9 @@ public interface VoteSummaryApi {
                                                       "time": "16:30",
                                                       "count": 1
                                                     }
+                                                  ],
+                                                  "myVotedTimes": [
+                                                    "15:00", "16:00"
                                                   ]
                                                 }
                                               }

--- a/src/main/java/pyws/swyp/meeting/dto/vote/VoteSummary.java
+++ b/src/main/java/pyws/swyp/meeting/dto/vote/VoteSummary.java
@@ -8,7 +8,6 @@ import pyws.swyp.meeting.dto.vote.time.TimeSummary;
 import pyws.swyp.meeting.entity.MeetingStatus;
 
 public record VoteSummary(
-        MeetingStatus meetingStatus,
         boolean isHost,
         LocalDate confirmedDate,
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")

--- a/src/main/java/pyws/swyp/meeting/dto/vote/time/TimeSummary.java
+++ b/src/main/java/pyws/swyp/meeting/dto/vote/time/TimeSummary.java
@@ -7,6 +7,8 @@ import java.util.List;
 public record TimeSummary(
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
         List<LocalTime> topTimes,
-        List<VotedTimeResponse> votedTimes
+        List<VotedTimeResponse> votedTimes,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
+        List<LocalTime> myVotedTimes
 ) {
 }

--- a/src/main/java/pyws/swyp/meeting/entity/Meeting.java
+++ b/src/main/java/pyws/swyp/meeting/entity/Meeting.java
@@ -38,7 +38,7 @@ public class Meeting extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 50)
-    private MeetingStatus status = MeetingStatus.VOTING;
+    private MeetingStatus status = MeetingStatus.IN_PROGRESS;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 50)
@@ -82,12 +82,10 @@ public class Meeting extends BaseEntity {
 
     public void confirmTime(LocalTime time) {
         this.time = time;
-        updateStatus(MeetingStatus.FIXED);
     }
 
     public void cancelConfirmedTime() {
         this.time = null;
-        updateStatus(MeetingStatus.VOTING);
     }
 
     public boolean isDateConfirmed() {

--- a/src/main/java/pyws/swyp/meeting/entity/MeetingStatus.java
+++ b/src/main/java/pyws/swyp/meeting/entity/MeetingStatus.java
@@ -6,16 +6,6 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Getter
 public enum MeetingStatus {
-
-    VOTING,   // 모임 생성됨 (투표 가능)
-    FIXED,     // 일정 확정됨 (투표 종료)
-    DONE;      // 모임 종료됨 (후기 가능)
-
-    public boolean isVotable() {
-        return this == VOTING;
-    }
-
-    public boolean isEnded() {
-        return this == DONE;
-    }
+    IN_PROGRESS,    // 모임 진행 중 (투표 중 / 일정 확정 후 대기)
+    DONE            // 모임 종료됨 (후기 가능)
 }

--- a/src/main/java/pyws/swyp/meeting/repository/MeetingRepository.java
+++ b/src/main/java/pyws/swyp/meeting/repository/MeetingRepository.java
@@ -28,20 +28,18 @@ public interface MeetingRepository extends JpaRepository<Meeting, Long> {
     @Query("""
             select m.id
             from Meeting m
-            where m.status = :status
-              and m.date is null
+            where m.date is null
               and m.time is null
             """)
-    List<Long> findIdsNeedingDateVoteReminder(MeetingStatus status);
+    List<Long> findIdsNeedingDateVoteReminder();
 
     @Query("""
             select m.id
             from Meeting m
-            where m.status = :status
-              and m.date is not null
+            where m.date is not null
               and m.time is null
             """)
-    List<Long> findIdsNeedingTimeVoteReminder(MeetingStatus status);
+    List<Long> findIdsNeedingTimeVoteReminder();
 
     Optional<Meeting> findByPublicId(UUID publicId);
 

--- a/src/main/java/pyws/swyp/meeting/repository/vote/TimeVoteRepository.java
+++ b/src/main/java/pyws/swyp/meeting/repository/vote/TimeVoteRepository.java
@@ -75,4 +75,13 @@ public interface TimeVoteRepository extends JpaRepository<TimeVote, Long> {
             where tv.meetingParticipant.id in :participantIds
             """)
     void deleteAllByParticipantIds(List<Long> participantIds);
+
+    @Query("""
+            select tv.time
+            from TimeVote tv
+            join tv.meetingParticipant mp
+            where mp.meeting.id = :meetingId
+              and mp.member.id = :memberId
+            """)
+    List<LocalTime> findMyVotedTimes(Long meetingId, Long memberId);
 }

--- a/src/main/java/pyws/swyp/meeting/service/HomeService.java
+++ b/src/main/java/pyws/swyp/meeting/service/HomeService.java
@@ -53,7 +53,7 @@ public class HomeService {
                         .toList();
 
         // 홈 하단 기다리고 있는 일정 카드
-        List<MeetingStatus> statuses = List.of(MeetingStatus.VOTING, MeetingStatus.FIXED);
+        List<MeetingStatus> statuses = List.of(MeetingStatus.IN_PROGRESS);
         List<MeetingBriefResponse> waitingMeetings
                 = meetingParticipantRepository.findMeetingsByMemberIdAndStatus(
                         memberId, statuses, PageRequest.of(0, DEFAULT_TOP));

--- a/src/main/java/pyws/swyp/meeting/service/MeetingConfirmService.java
+++ b/src/main/java/pyws/swyp/meeting/service/MeetingConfirmService.java
@@ -37,9 +37,6 @@ public class MeetingConfirmService {
     private final TimeVoteRepository timeVoteRepository;
     private final ApplicationEventPublisher eventPublisher;
 
-    /**
-     * 모임장이 날짜 투표 결과를 기준으로 모임 날짜를 확정한다.
-     */
     public void confirmDateVote(Long memberId, Long meetingId) {
         Meeting meeting = getMeeting(meetingId);
         MeetingParticipant participant = getParticipant(memberId, meetingId);
@@ -59,9 +56,6 @@ public class MeetingConfirmService {
         eventPublisher.publishEvent(new DateVoteConfirmedEvent(meetingId));
     }
 
-    /**
-     * 모임장이 지정한 날짜로 모임 날짜를 임의 확정한다.
-     */
     public void confirmDate(Long memberId, Long meetingId, LocalDate date) {
         Meeting meeting = getMeeting(meetingId);
         MeetingParticipant participant = getParticipant(memberId, meetingId);
@@ -73,9 +67,6 @@ public class MeetingConfirmService {
         eventPublisher.publishEvent(new DateVoteConfirmedEvent(meetingId));
     }
 
-    /**
-     * 날짜 확정을 취소한다.
-     */
     public void cancelConfirmDateVote(Long memberId, Long meetingId) {
         Meeting meeting = getMeeting(meetingId);
         MeetingParticipant participant = getParticipant(memberId, meetingId);
@@ -86,9 +77,6 @@ public class MeetingConfirmService {
         meeting.cancelConfirmedDate();
     }
 
-    /**
-     * 모임장이 시간 투표 결과를 기준으로 모임 시간을 확정하고, 모임을 FIXED 상태로 변경한다.
-     */
     public void confirmTimeVote(Long memberId, Long meetingId) {
         Meeting meeting = getMeeting(meetingId);
         MeetingParticipant participant = getParticipant(memberId, meetingId);
@@ -105,9 +93,6 @@ public class MeetingConfirmService {
         eventPublisher.publishEvent(new TimeVoteConfirmedEvent(meetingId));
     }
 
-    /**
-     * 모임장이 지정한 시간으로 모임 시간을 임의 확정하고, 모임을 FIXED 상태로 변경한다.
-     */
     public void confirmTime(Long memberId, Long meetingId, LocalTime time) {
         Meeting meeting = getMeeting(meetingId);
         MeetingParticipant participant = getParticipant(memberId, meetingId);
@@ -120,9 +105,6 @@ public class MeetingConfirmService {
         eventPublisher.publishEvent(new TimeVoteConfirmedEvent(meetingId));
     }
 
-    /**
-     * 시간 확정을 취소하고, 모임을 VOTING 상태로 되돌린다.
-     */
     public void cancelConfirmTimeVote(Long memberId, Long meetingId) {
         Meeting meeting = getMeeting(meetingId);
         MeetingParticipant participant = getParticipant(memberId, meetingId);
@@ -164,7 +146,7 @@ public class MeetingConfirmService {
     }
 
     private void validateTimeCancelable(Meeting meeting) {
-        if (meeting.getStatus() != MeetingStatus.FIXED) {
+        if (meeting.getStatus() == MeetingStatus.DONE) {
             throw ErrorCode.MEETING_NOT_TIME_CANCELABLE.toException();
         }
 

--- a/src/main/java/pyws/swyp/meeting/service/MeetingService.java
+++ b/src/main/java/pyws/swyp/meeting/service/MeetingService.java
@@ -86,7 +86,7 @@ public class MeetingService {
 
     @Transactional(readOnly = true)
     public List<MeetingBriefResponse> getWaitingMeetings(Long memberId, Pageable pageable) {
-        List<MeetingStatus> statuses = List.of(MeetingStatus.VOTING, MeetingStatus.FIXED);
+        List<MeetingStatus> statuses = List.of(MeetingStatus.IN_PROGRESS);
         return meetingParticipantRepository.findMeetingsByMemberIdAndStatus(memberId, statuses, pageable);
     }
 

--- a/src/main/java/pyws/swyp/meeting/service/vote/VoteSummaryService.java
+++ b/src/main/java/pyws/swyp/meeting/service/vote/VoteSummaryService.java
@@ -14,7 +14,6 @@ import pyws.swyp.meeting.dto.vote.time.TimeSummary;
 import pyws.swyp.meeting.dto.vote.time.VotedTimeResponse;
 import pyws.swyp.meeting.entity.Meeting;
 import pyws.swyp.meeting.entity.MeetingParticipant;
-import pyws.swyp.meeting.entity.MeetingStatus;
 import pyws.swyp.meeting.repository.MeetingParticipantRepository;
 import pyws.swyp.meeting.repository.MeetingRepository;
 import pyws.swyp.meeting.repository.vote.DateVoteRepository;
@@ -42,10 +41,9 @@ public class VoteSummaryService {
 
         boolean isHost = participant.isHost();
         DateSummary dateSummary = getDateSummary(meetingId);
-        TimeSummary timeSummary = getTimeSummary(meetingId);
+        TimeSummary timeSummary = getTimeSummary(meetingId, memberId);
 
         return new VoteSummary(
-                meeting.getStatus(),
                 isHost,
                 meeting.getDate(),
                 meeting.getTime(),
@@ -63,12 +61,12 @@ public class VoteSummaryService {
         return new DateSummary(topDates, votedDates);
     }
 
-    private TimeSummary getTimeSummary(Long meetingId) {
+    private TimeSummary getTimeSummary(Long meetingId, Long memberId) {
         List<LocalTime> topTimes = timeVoteRepository.findTopTimesByMeetingId(
                 meetingId, PageRequest.of(0, TOP_N)
         );
         List<VotedTimeResponse> votedTimes = timeVoteRepository.findVotedTimesWithCounts(meetingId);
-
-        return new TimeSummary(topTimes, votedTimes);
+        List<LocalTime> myVotedTimes = timeVoteRepository.findMyVotedTimes(meetingId, memberId);
+        return new TimeSummary(topTimes, votedTimes, myVotedTimes);
     }
 }

--- a/src/main/java/pyws/swyp/notification/scheduler/VoteReminderScheduler.java
+++ b/src/main/java/pyws/swyp/notification/scheduler/VoteReminderScheduler.java
@@ -19,11 +19,11 @@ public class VoteReminderScheduler {
     public void remindVote() {
 
         // 날짜 투표 진행 중인 모임
-        List<Long> dateVotingMeetingIds = meetingRepository.findIdsNeedingDateVoteReminder(MeetingStatus.VOTING);
+        List<Long> dateVotingMeetingIds = meetingRepository.findIdsNeedingDateVoteReminder();
         dateVotingMeetingIds.forEach(meetingNotificationService::remindDateVote);
 
         // 시간 투표 진행 중인 모임
-        List<Long> timeVotingMeetingIds = meetingRepository.findIdsNeedingTimeVoteReminder(MeetingStatus.VOTING);
+        List<Long> timeVotingMeetingIds = meetingRepository.findIdsNeedingTimeVoteReminder();
         timeVotingMeetingIds.forEach(meetingNotificationService::remindTimeVote);
     }
 }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -13,10 +13,12 @@ SET FOREIGN_KEY_CHECKS = 0;
 ------------------------------------------------------
 
 -- MEETING
-INSERT IGNORE INTO meeting (id, public_id, created_at, is_active, updated_at, date, time, status, type, title)
+INSERT IGNORE INTO meeting (id, public_id, created_at, is_active, updated_at, date, time, status, type, title, course_fixed)
 VALUES
-    (1, UUID_TO_BIN(UUID()), NOW(), 1, NULL, '2025-12-20', NULL, 'VOTING', 'FOODIE', '연말 모임'),
-    (2, UUID_TO_BIN(UUID()), NOW(), 1, NULL, '2025-12-25', '19:00:00', 'FIXED', 'TREND_SETTER','크리스마스 모임');
+    (1, UUID_TO_BIN(UUID()), NOW(), 1, NULL, '2025-12-20', '12:00', 'DONE', 'FOODIE', '연말 모임', true),
+    (2, UUID_TO_BIN(UUID()), NOW(), 1, NULL, '2025-12-25', '15:00', 'DONE', 'TREND_SETTER','크리스마스 모임', true),
+    (3, UUID_TO_BIN(UUID()), NOW(), 1, NULL, '2026-02-15', '19:00', 'IN_PROGRESS', 'TREND_SETTER','크리스마스 모임', true),
+    (4, UUID_TO_BIN(UUID()), NOW(), 1, NULL, '2025-02-25', NULL, 'IN_PROGRESS', 'TREND_SETTER','크리스마스 모임', false);
 
 -- MEMBER
 INSERT IGNORE INTO member (id, created_at, birth_date, email, gender, nickname, character_type, role)
@@ -37,11 +39,11 @@ VALUES (1, NOW(), 1, NULL, 'HOST', 1, 1),
        (4, NOW(), 1, NULL, 'HOST', 1, 4),
        (5, NOW(), 1, NULL, 'MEMBER', 2, 4);
 
--- COURSE
-INSERT IGNORE INTO course (id, created_at, is_active, updated_at, step, meeting_id)
-VALUES (1, NOW(), 1, NULL, 1, 1),
-       (2, NOW(), 1, NULL, 2, 1),
-       (3, NOW(), 1, NULL, 1, 2);
+# -- COURSE
+# INSERT IGNORE INTO course (id, created_at, is_active, updated_at, step, meeting_id)
+# VALUES (1, NOW(), 1, NULL, 1, 1),
+#        (2, NOW(), 1, NULL, 2, 1),
+#        (3, NOW(), 1, NULL, 1, 2);
 
 -- DATE_VOTE
 INSERT IGNORE INTO date_vote (id, created_at, meeting_participant_id, meeting_id, date)
@@ -53,24 +55,26 @@ VALUES (1, NOW(), 1, 1, '2025-12-20'),
 
 -- TIME_VOTE
 INSERT IGNORE INTO time_vote (id, created_at, meeting_id, meeting_participant_id, time)
-VALUES (1, NOW(), 2, 1, '15:00:00'), -- host
-       (2, NOW(), 2, 2, '15:00:00'), -- member1
-       (3, NOW(), 2, 3, '16:00:00'); -- member2
+VALUES (1, NOW(), 2, 1, '15:00'), -- host
+       (2, NOW(), 2, 2, '15:00'), -- member1
+       (3, NOW(), 2, 3, '16:00'), -- member2
+       (4, NOW(), 2, 4, '16:30'), -- member2
+       (5, NOW(), 2, 5, '17:00'); -- member2
 
--- PLACE_OPTION
-INSERT IGNORE INTO place_option (id, created_at, is_active, updated_at, status, course_id)
-VALUES (1, NOW(), 1, NULL, 'OPTION', 1),
-       (2, NOW(), 1, NULL, 'OPTION', 1),
-       (3, NOW(), 1, NULL, 'OPTION', 2),
-       (4, NOW(), 1, NULL, 'FIXED', 3);
-
--- PLACE_VOTE
-INSERT IGNORE INTO place_vote (id, created_at, is_active, updated_at, course_id, meeting_participant_id,
-                               place_option_id)
-VALUES (1, NOW(), 1, NULL, 1, 1, 1),
-       (2, NOW(), 1, NULL, 1, 2, 2),
-       (3, NOW(), 1, NULL, 2, 3, 3),
-       (4, NOW(), 1, NULL, 3, 4, 4);
+# -- PLACE_OPTION
+# INSERT IGNORE INTO place_option (id, created_at, is_active, updated_at, status, course_id)
+# VALUES (1, NOW(), 1, NULL, 'OPTION', 1),
+#        (2, NOW(), 1, NULL, 'OPTION', 1),
+#        (3, NOW(), 1, NULL, 'OPTION', 2),
+#        (4, NOW(), 1, NULL, 'FIXED', 3);
+#
+# -- PLACE_VOTE
+# INSERT IGNORE INTO place_vote (id, created_at, is_active, updated_at, course_id, meeting_participant_id,
+#                                place_option_id)
+# VALUES (1, NOW(), 1, NULL, 1, 1, 1),
+#        (2, NOW(), 1, NULL, 1, 2, 2),
+#        (3, NOW(), 1, NULL, 2, 3, 3),
+#        (4, NOW(), 1, NULL, 3, 4, 4);
 
 -- NOTIFICATION
 INSERT IGNORE INTO notification (id, created_at, is_active, updated_at, member_id, type, status, title, body, deep_link,
@@ -109,7 +113,14 @@ INSERT IGNORE INTO meeting_record (id, created_at, is_active, updated_at, meetin
 VALUES
     (1, NOW(), 1, NULL, 1, 4,'분위기도 좋고 시간 조율이 잘 돼서 정말 만족스러운 모임이었어요.'),
     (2, NOW(), 1, NULL, 2, 4,'처음 만나는 분들이었는데 어색하지 않게 잘 진행됐어요.'),
-    (3, NOW(), 1, NULL, 2, 4,'장소 선정이 특히 마음에 들었고 다음에도 참여하고 싶어요.'),
-    (4, NOW(), 1, NULL, 2, 4,'투표 과정이 편리해서 일정 잡기가 쉬웠습니다.');
+    (3, NOW(), 1, NULL, 3, 4,'장소 선정이 특히 마음에 들었고 다음에도 참여하고 싶어요.'),
+    (4, NOW(), 1, NULL, 4, 4,'투표 과정이 편리해서 일정 잡기가 쉬웠습니다.');
 
+-- RECORD_IMAGE
+INSERT IGNORE INTO record_image (id, created_at, is_active, updated_at, image_key, sort_order, meeting_review_id)
+VALUES
+    (1, NOW(), 1, NULL, 'image1.png', 1, 1),
+    (2, NOW(), 1, NULL, 'image2.png', 2, 1),
+    (3, NOW(), 1, NULL, 'image3.png', 1, 2),
+    (4, NOW(), 1, NULL, 'image4.png', 2, 2);
 SET FOREIGN_KEY_CHECKS = 1;

--- a/src/test/java/pyws/swyp/meeting/controller/MeetingConfirmControllerTest.java
+++ b/src/test/java/pyws/swyp/meeting/controller/MeetingConfirmControllerTest.java
@@ -80,7 +80,6 @@ class MeetingConfirmControllerTest {
                 .title("확정 테스트 모임")
                 .type(MeetingType.DRINKER)
                 .build());
-        meeting.updateStatus(MeetingStatus.VOTING);
         this.meetingId = meeting.getId();
 
         meetingParticipantRepository.save(MeetingParticipant.builder()
@@ -106,7 +105,6 @@ class MeetingConfirmControllerTest {
 
         // then
         Meeting updated = meetingRepository.findById(meetingId).orElseThrow();
-        assertEquals(MeetingStatus.VOTING, updated.getStatus());
         assertEquals(chosen, updated.getDate());
     }
 
@@ -124,7 +122,6 @@ class MeetingConfirmControllerTest {
 
         // then
         Meeting updated = meetingRepository.findById(meetingId).orElseThrow();
-        assertEquals(MeetingStatus.FIXED, updated.getStatus());
         assertEquals(chosen, updated.getTime());
     }
 
@@ -144,7 +141,6 @@ class MeetingConfirmControllerTest {
 
         // then
         Meeting updated = meetingRepository.findById(meetingId).orElseThrow();
-        assertEquals(MeetingStatus.VOTING, updated.getStatus());
         assertNull(updated.getDate());
     }
 

--- a/src/test/java/pyws/swyp/meeting/controller/vote/DateVoteControllerTest.java
+++ b/src/test/java/pyws/swyp/meeting/controller/vote/DateVoteControllerTest.java
@@ -102,7 +102,6 @@ class DateVoteControllerTest {
                 .title("테스트 모임")
                 .type(MeetingType.DRINKER)
                 .build());
-        meeting.updateStatus(MeetingStatus.VOTING);
         this.meetingId = meeting.getId();
 
         // participants

--- a/src/test/java/pyws/swyp/meeting/controller/vote/TimeVoteControllerTest.java
+++ b/src/test/java/pyws/swyp/meeting/controller/vote/TimeVoteControllerTest.java
@@ -106,7 +106,6 @@ class TimeVoteControllerTest {
                 .title("테스트 모임")
                 .type(MeetingType.DRINKER)
                 .build());
-        meeting.updateStatus(MeetingStatus.VOTING);
         meetingRepository.save(meeting);
         this.meetingId = meeting.getId();
 

--- a/src/test/java/pyws/swyp/meeting/service/HomeServiceTest.java
+++ b/src/test/java/pyws/swyp/meeting/service/HomeServiceTest.java
@@ -31,7 +31,6 @@ public class HomeServiceTest {
     private HomeService homeService;
 
     @Test
-    @DisplayName("")
     void 홈화면_조회_성공() {
         // given
         Long memberId = 1L;
@@ -39,9 +38,9 @@ public class HomeServiceTest {
         LocalDate fixedEnd = fixedNow.plusDays(7);
 
         List<MeetingBriefResponse> meetingInfos = List.of(
-                new MeetingBriefResponse(3L, "데이트", MeetingStatus.FIXED, fixedNow.plusDays(2)),
-                new MeetingBriefResponse(1L, "모잇 오프라인 모임", MeetingStatus.FIXED, fixedNow.plusDays(4)),
-                new MeetingBriefResponse(2L, "카공", MeetingStatus.FIXED, fixedNow.plusDays(6))
+                new MeetingBriefResponse(3L, "데이트", MeetingStatus.IN_PROGRESS, fixedNow.plusDays(2)),
+                new MeetingBriefResponse(1L, "모잇 오프라인 모임", MeetingStatus.IN_PROGRESS, fixedNow.plusDays(4)),
+                new MeetingBriefResponse(2L, "카공", MeetingStatus.IN_PROGRESS, fixedNow.plusDays(6))
         );
 
         ParticipantInfo p1 = new ParticipantInfo(memberId, "닉네임1", CharacterType.FOODIE, pyws.swyp.meeting.entity.ParticipantRole.HOST);
@@ -61,10 +60,10 @@ public class HomeServiceTest {
         );
 
         List<MeetingBriefResponse> waitingMeetings = List.of(
-                new MeetingBriefResponse(1L, "모잇 오프라인 모임", MeetingStatus.FIXED, fixedNow.plusDays(4)),
-                new MeetingBriefResponse(2L, "카공", MeetingStatus.FIXED, fixedNow.plusDays(6)),
-                new MeetingBriefResponse(4L, "보드게임 모임", MeetingStatus.VOTING, null),
-                new MeetingBriefResponse(5L, "동아리 전체 회식", MeetingStatus.VOTING, null)
+                new MeetingBriefResponse(1L, "모잇 오프라인 모임", MeetingStatus.IN_PROGRESS, fixedNow.plusDays(4)),
+                new MeetingBriefResponse(2L, "카공", MeetingStatus.IN_PROGRESS, fixedNow.plusDays(6)),
+                new MeetingBriefResponse(4L, "보드게임 모임", MeetingStatus.IN_PROGRESS, null),
+                new MeetingBriefResponse(5L, "동아리 전체 회식", MeetingStatus.IN_PROGRESS, null)
         );
 
         when(meetingParticipantRepository.findMeetingsByMemberIdWithin7Days(memberId, fixedNow, fixedEnd))

--- a/src/test/java/pyws/swyp/meeting/service/MeetingCalendarServiceTest.java
+++ b/src/test/java/pyws/swyp/meeting/service/MeetingCalendarServiceTest.java
@@ -78,7 +78,6 @@ class MeetingCalendarServiceTest {
                     .title("테스트 모임 " + i)
                     .type(MeetingType.ACTIVE)
                     .build();
-            meeting.updateStatus(MeetingStatus.FIXED);
             meeting.confirmDate(LocalDate.of(2026, 1, 1 + i));
             meeting.confirmTime(LocalTime.of(11 + i, 0));
             meetings.add(meeting);

--- a/src/test/java/pyws/swyp/meeting/service/MeetingConfirmServiceTest.java
+++ b/src/test/java/pyws/swyp/meeting/service/MeetingConfirmServiceTest.java
@@ -66,7 +66,6 @@ class MeetingConfirmServiceTest {
                 .title("테스트 모임")
                 .type(MeetingType.DRINKER)
                 .build();
-        meeting.updateStatus(MeetingStatus.VOTING);
         meetingRepository.save(meeting);
         this.meetingId = meeting.getId();
         this.meeting = meeting;
@@ -132,7 +131,6 @@ class MeetingConfirmServiceTest {
 
         // then
         Meeting meeting = meetingRepository.findById(meetingId).orElseThrow();
-        assertEquals(MeetingStatus.VOTING, meeting.getStatus());
         assertEquals(LocalDate.of(2025, 1, 1), meeting.getDate());
     }
 
@@ -147,7 +145,6 @@ class MeetingConfirmServiceTest {
 
         // then
         Meeting meeting = meetingRepository.findById(meetingId).orElseThrow();
-        assertEquals(MeetingStatus.VOTING, meeting.getStatus());
         assertEquals(chosen, meeting.getDate());
     }
 
@@ -162,24 +159,22 @@ class MeetingConfirmServiceTest {
 
         // then
         Meeting meeting = meetingRepository.findById(meetingId).orElseThrow();
-        assertEquals(MeetingStatus.VOTING, meeting.getStatus());
         assertNull(meeting.getDate());
     }
 
     @Test
-    @DisplayName("모임장이 최다 득표 시간으로 확정하면 모임 상태가 FIXED가 된다.")
+    @DisplayName("모임장이 최다 득표 시간으로 확정한다.")
     void confirmTimeVote_success() {
         // when
         meetingConfirmService.confirmTimeVote(hostMemberId, meetingId);
 
         // then
         Meeting updated = meetingRepository.findById(meetingId).orElseThrow();
-        assertEquals(MeetingStatus.FIXED, updated.getStatus());
         assertEquals(LocalTime.of(15, 30), updated.getTime());
     }
 
     @Test
-    @DisplayName("모임장이 지정한 시간으로 확정하면 모임 상태가 FIXED가 된다.")
+    @DisplayName("모임장이 지정한 시간으로 확정한다.")
     void confirmTime_manual_success() {
         // given
         LocalTime chosen = LocalTime.of(20, 0);
@@ -189,12 +184,11 @@ class MeetingConfirmServiceTest {
 
         // then
         Meeting updated = meetingRepository.findById(meetingId).orElseThrow();
-        assertEquals(MeetingStatus.FIXED, updated.getStatus());
         assertEquals(chosen, updated.getTime());
     }
 
     @Test
-    @DisplayName("모임장이 모임 시간 확정을 취소하면 VOTING으로 바뀌고 확정 시간은 null이 된다.")
+    @DisplayName("모임장이 모임 시간 확정을 취소하면 확정 시간은 null이 된다.")
     void cancelConfirmTimeVote_success() {
         // given
         meetingConfirmService.confirmTime(hostMemberId, meetingId, LocalTime.of(20, 0));
@@ -204,7 +198,6 @@ class MeetingConfirmServiceTest {
 
         // then
         Meeting updated = meetingRepository.findById(meetingId).orElseThrow();
-        assertEquals(MeetingStatus.VOTING, updated.getStatus());
         assertNull(updated.getTime());
     }
 

--- a/src/test/java/pyws/swyp/meeting/service/MeetingRecordServiceTest.java
+++ b/src/test/java/pyws/swyp/meeting/service/MeetingRecordServiceTest.java
@@ -85,7 +85,6 @@ class MeetingRecordServiceTest {
                 .build();
         meetingNotDone.confirmDate(LocalDate.of(2026, 1, 2));
         meetingNotDone.confirmTime(LocalTime.of(19, 0));
-        meetingNotDone.updateStatus(MeetingStatus.FIXED);
         meetingRepository.save(meetingNotDone);
 
         member = memberRepository.save(Member.builder()

--- a/src/test/java/pyws/swyp/meeting/service/MeetingServiceTest.java
+++ b/src/test/java/pyws/swyp/meeting/service/MeetingServiceTest.java
@@ -455,7 +455,7 @@ public class MeetingServiceTest {
     }
 
     @Test
-    @DisplayName("대기 중 모임 조회 성공 - VOTING, FIXED 상태만 조회")
+    @DisplayName("대기 중 모임 조회 성공 - IN_PROGRESS 상태만 조회")
     void 대기중_모임_조회_성공() {
         // given
         Long memberId = 1L;
@@ -478,8 +478,7 @@ public class MeetingServiceTest {
                 .findMeetingsByMemberIdAndStatus(
                         eq(memberId),
                         eq(List.of(
-                                MeetingStatus.VOTING,
-                                MeetingStatus.FIXED
+                                MeetingStatus.IN_PROGRESS
                         )),
                         eq(pageable)
                 );

--- a/src/test/java/pyws/swyp/meeting/service/vote/DateVoteServiceTest.java
+++ b/src/test/java/pyws/swyp/meeting/service/vote/DateVoteServiceTest.java
@@ -71,7 +71,6 @@ class DateVoteServiceTest {
                 .title("테스트 모임")
                 .type(MeetingType.DRINKER)
                 .build();
-        meeting.updateStatus(MeetingStatus.VOTING);
         this.meeting = meetingRepository.save(meeting);
 
         List<Member> members = new ArrayList<>();

--- a/src/test/java/pyws/swyp/meeting/service/vote/TimeVoteServiceTest.java
+++ b/src/test/java/pyws/swyp/meeting/service/vote/TimeVoteServiceTest.java
@@ -79,7 +79,6 @@ class TimeVoteServiceTest {
                 .title("테스트 모임")
                 .type(MeetingType.DRINKER)
                 .build();
-        meeting.updateStatus(MeetingStatus.VOTING);
         this.meeting = meetingRepository.save(meeting);
 
         List<Member> members = new ArrayList<>();

--- a/src/test/java/pyws/swyp/meeting/service/vote/VoteSummaryServiceTest.java
+++ b/src/test/java/pyws/swyp/meeting/service/vote/VoteSummaryServiceTest.java
@@ -159,7 +159,6 @@ class VoteSummaryServiceTest {
         );
 
         // then
-        assertEquals(MeetingStatus.VOTING, response.meetingStatus());
         assertFalse(response.isHost());
 
         DateSummary dateSummary = response.dateSummary();
@@ -178,5 +177,8 @@ class VoteSummaryServiceTest {
                 new VotedTimeResponse(t4, 1)
         );
         assertEquals(expected, timeSummary.votedTimes());
+
+        List<LocalTime> myVotedTimes = timeSummary.myVotedTimes();
+        assertEquals(List.of(t1, t2), myVotedTimes);
     }
 }

--- a/src/test/java/pyws/swyp/member/service/MemberServiceTest.java
+++ b/src/test/java/pyws/swyp/member/service/MemberServiceTest.java
@@ -124,7 +124,6 @@ class MemberServiceTest {
                 .title("테스트 모임")
                 .type(MeetingType.CULTURE_LOVER)
                 .build();
-        meeting.updateStatus(MeetingStatus.VOTING);
         meetingRepository.save(meeting);
         this.meetingId = meeting.getId();
 


### PR DESCRIPTION
### 📌 PR 타입
- 리팩토링

### 📌 관련 이슈
close #48 

### ✨ 반영 브랜치
feat/48 -> develop

### 📝 변경 사항
- [x] MeetingStatus enum 값을 `IN_PROGRESS`, `DONE`로 수정
- [x] enum 변경에 따른 관련 코드 및 테스트를 수정
- [x] `VoteSummary` 응답에 `myVotedTimes` 필드를 추가

### ➕ 추가 메모
- 변경된 `Vote Summary` 응답
```json
{
  "code": "SUCCESS",
  "message": "요청이 성공적으로 처리되었습니다.",
  "data": {
    "isHost": false,
    "confirmedDate": "2025-12-25",
    "confirmedTime": "15:00",
    "dateSummary": {
      "topDates": [
        "2025-12-25",
        "2025-12-26"
      ],
      "votedDates": [
        "2025-12-25",
        "2025-12-26"
      ]
    },
    "timeSummary": {
      "topTimes": [
        "15:00"
      ],
      "votedTimes": [
        {
          "time": "15:00",
          "count": 2
        },
        {
          "time": "16:00",
          "count": 1
        },
        {
          "time": "16:30",
          "count": 1
        },
        {
          "time": "17:00",
          "count": 1
        }
      ],
      "myVotedTimes": [
        "17:00"
      ]
    }
  }
}
```

### 🐛 테스트 결과
<img width="501" height="30" alt="image" src="https://github.com/user-attachments/assets/21f977f6-9d82-4494-8ae1-3ff48bc62f96" />